### PR TITLE
Fix broken SwaggerDict pickling

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -54,7 +54,6 @@
       </option>
     </inspection_tool>
     <inspection_tool class="PyShadowingNamesInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyUnusedLocalInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false">
       <option name="ignoreTupleUnpacking" value="true" />
       <option name="ignoreLambdaParameters" value="true" />

--- a/docs/drf_yasg.rst
+++ b/docs/drf_yasg.rst
@@ -57,6 +57,7 @@ drf\_yasg\.openapi
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: _bare_SwaggerDict
 
 drf\_yasg\.renderers
 ------------------------------

--- a/src/drf_yasg/codecs.py
+++ b/src/drf_yasg/codecs.py
@@ -87,7 +87,7 @@ class _OpenAPICodec(object):
         :rtype: OrderedDict
         """
         swagger.security_definitions = swagger_settings.SECURITY_DEFINITIONS
-        return swagger
+        return swagger.as_odict()
 
 
 class OpenAPICodecJson(_OpenAPICodec):
@@ -146,9 +146,24 @@ SaneYamlDumper.add_representer(OrderedDict, SaneYamlDumper.represent_odict)
 SaneYamlDumper.add_multi_representer(OrderedDict, SaneYamlDumper.represent_odict)
 
 
+def yaml_sane_dump(data, binary):
+    """Dump the given data dictionary into a sane format:
+
+        * OrderedDicts are dumped as regular mappings instead of non-standard !!odict
+        * multi-line mapping style instead of json-like inline style
+        * list elements are indented into their parents
+
+    :param dict data: the data to be serializers
+    :param bool binary: True to return a utf-8 encoded binary object, False to return a string
+    :return: the serialized YAML
+    :rtype: str,bytes
+    """
+    return yaml.dump(data, Dumper=SaneYamlDumper, default_flow_style=False, encoding='utf-8' if binary else None)
+
+
 class OpenAPICodecYaml(_OpenAPICodec):
     media_type = 'application/yaml'
 
     def _dump_dict(self, spec):
         """Dump ``spec`` into YAML."""
-        return yaml.dump(spec, Dumper=SaneYamlDumper, default_flow_style=False, encoding='utf-8')
+        return yaml_sane_dump(spec, binary=True)

--- a/testproj/testproj/urls.py
+++ b/testproj/testproj/urls.py
@@ -29,7 +29,10 @@ def plain_view(request):
 urlpatterns = [
     url(r'^swagger(?P<format>.json|.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=None), name='schema-redoc'),
+    url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+    url(r'^cached/swagger(?P<format>.json|.yaml)$', schema_view.without_ui(cache_timeout=None), name='schema-json'),
+    url(r'^cached/swagger/$', schema_view.with_ui('swagger', cache_timeout=None), name='schema-swagger-ui'),
+    url(r'^cached/redoc/$', schema_view.with_ui('redoc', cache_timeout=None), name='schema-redoc'),
 
     url(r'^admin/', admin.site.urls),
     url(r'^snippets/', include('snippets.urls')),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,8 +45,8 @@ def validate_schema():
         from flex.core import parse as validate_flex
         from swagger_spec_validator.validator20 import validate_spec as validate_ssv
 
-        validate_flex(swagger)
-        validate_ssv(swagger)
+        validate_flex(copy.deepcopy(swagger))
+        validate_ssv(copy.deepcopy(swagger))
 
     return validate_schema
 

--- a/tests/test_schema_views.py
+++ b/tests/test_schema_views.py
@@ -46,6 +46,18 @@ def test_redoc(client, validate_schema):
     _validate_text_schema_view(client, validate_schema, '/redoc/?format=openapi', json.loads)
 
 
+def test_caching(client, validate_schema):
+    def run_once():
+        _validate_ui_schema_view(client, '/cached/redoc/', 'redoc/redoc.min.js')
+        _validate_text_schema_view(client, validate_schema, '/cached/redoc/?format=openapi', json.loads)
+        _validate_ui_schema_view(client, '/cached/swagger/', 'swagger-ui-dist/swagger-ui-bundle.js')
+        _validate_text_schema_view(client, validate_schema, '/cached/swagger/?format=openapi', json.loads)
+        _validate_text_schema_view(client, validate_schema, "/cached/swagger.yaml", yaml.safe_load)
+
+    for i in range(3):
+        run_once()
+
+
 @pytest.mark.urls('urlconfs.non_public_urls')
 def test_non_public(client):
     response = client.get('/private/swagger.yaml')

--- a/tests/test_schema_views.py
+++ b/tests/test_schema_views.py
@@ -1,4 +1,5 @@
 import json
+from collections import OrderedDict
 
 import pytest
 from ruamel import yaml
@@ -47,15 +48,23 @@ def test_redoc(client, validate_schema):
 
 
 def test_caching(client, validate_schema):
-    def run_once():
+    prev_schema = None
+
+    for i in range(3):
         _validate_ui_schema_view(client, '/cached/redoc/', 'redoc/redoc.min.js')
         _validate_text_schema_view(client, validate_schema, '/cached/redoc/?format=openapi', json.loads)
         _validate_ui_schema_view(client, '/cached/swagger/', 'swagger-ui-dist/swagger-ui-bundle.js')
         _validate_text_schema_view(client, validate_schema, '/cached/swagger/?format=openapi', json.loads)
-        _validate_text_schema_view(client, validate_schema, "/cached/swagger.yaml", yaml.safe_load)
 
-    for i in range(3):
-        run_once()
+        json_schema = client.get('/cached/swagger.json')
+        assert json_schema.status_code == 200
+        json_schema = json.loads(json_schema.content.decode('utf-8'), object_pairs_hook=OrderedDict)
+        if prev_schema is None:
+            validate_schema(json_schema)
+            prev_schema = json_schema
+        else:
+            from datadiff.tools import assert_equal
+            assert_equal(prev_schema, json_schema)
 
 
 @pytest.mark.urls('urlconfs.non_public_urls')


### PR DESCRIPTION
The second request to a cached endpoint fails with an AttributeError.

This is probably caused by broken picklnig due to SwaggerDict deepcopy returning an OrderedDict.