### PR TITLE
Refactor inspectors to be more pluggable

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,15 +11,15 @@ coverage:
       default:
         enabled: yes
         target: auto
-        threshold: 0%
+        threshold: 100%
         if_no_uploads: error
         if_ci_failed: error
 
     patch:
       default:
         enabled: yes
-        target: 80%
-        threshold: 0%
+        target: 100%
+        threshold: 100%
         if_no_uploads: error
         if_ci_failed: error
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -17,6 +17,7 @@ exclude_lines =
     raise TypeError
     raise NotImplementedError
     warnings.warn
+    logger.warning
 
     # Don't complain if non-runnable code isn't run:
     if 0:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -186,6 +186,7 @@ nitpick_ignore = [
     ('py:obj', 'callable'),
     ('py:obj', 'type'),
     ('py:obj', 'OrderedDict'),
+    ('py:obj', 'None'),
 
     ('py:obj', 'coreapi.Field'),
     ('py:obj', 'BaseFilterBackend'),

--- a/docs/drf_yasg.rst
+++ b/docs/drf_yasg.rst
@@ -16,7 +16,7 @@ drf\_yasg\.codecs
     :members:
     :undoc-members:
     :show-inheritance:
-    :exclude-members: SaneYamlDumper
+    :exclude-members: SaneYamlDumper,SaneYamlLoader
 
 drf\_yasg\.errors
 ---------------------------

--- a/src/drf_yasg/app_settings.py
+++ b/src/drf_yasg/app_settings.py
@@ -1,7 +1,21 @@
 from django.conf import settings
 from rest_framework.settings import perform_import
 
+
 SWAGGER_DEFAULTS = {
+    'DEFAULT_AUTO_SCHEMA_CLASS': 'drf_yasg.inspectors.SwaggerAutoSchema',
+
+    'DEFAULT_SERIALIZER_INSPECTORS': [
+        'drf_yasg.inspectors.ReferencingSerializerInspector'
+    ],
+    'DEFAULT_FILTER_INSPECTORS': [
+        'drf_yasg.inspectors.CoreAPICompatInspector',
+    ],
+    'DEFAULT_PAGINATOR_INSPECTORS': [
+        'drf_yasg.inspectors.DjangoRestResponsePagination',
+        'drf_yasg.inspectors.CoreAPICompatInspector',
+    ],
+
     'USE_SESSION_AUTH': True,
     'SECURITY_DEFINITIONS': {
         'basic': {
@@ -28,7 +42,12 @@ REDOC_DEFAULTS = {
     'PATH_IN_MIDDLE': False,
 }
 
-IMPORT_STRINGS = []
+IMPORT_STRINGS = [
+    'DEFAULT_AUTO_SCHEMA_CLASS',
+    'DEFAULT_SERIALIZER_INSPECTORS',
+    'DEFAULT_FILTER_INSPECTORS',
+    'DEFAULT_PAGINATOR_INSPECTORS',
+]
 
 
 class AppSettings(object):

--- a/src/drf_yasg/inspectors.py
+++ b/src/drf_yasg/inspectors.py
@@ -69,7 +69,7 @@ class BaseInspector(object):
                 return result
 
         logger.warning("%s ignored because no inspector in %s handled it (operation: %s)", obj, inspectors, method_name)
-        return None
+        return None  # pragma: no cover
 
 
 class ViewInspector(BaseInspector):

--- a/src/drf_yasg/inspectors.py
+++ b/src/drf_yasg/inspectors.py
@@ -1,8 +1,10 @@
 import inspect
+import logging
 from collections import OrderedDict
 
 import coreschema
 from rest_framework import serializers, status
+from rest_framework.pagination import CursorPagination, PageNumberPagination, LimitOffsetPagination
 from rest_framework.request import is_form_media_type
 from rest_framework.schemas import AutoSchema
 from rest_framework.status import is_success
@@ -11,6 +13,8 @@ from rest_framework.viewsets import GenericViewSet
 from . import openapi
 from .errors import SwaggerGenerationError
 from .utils import serializer_field_to_swagger, no_body, is_list_view, param_list_to_odict
+
+logger = logging.getLogger(__name__)
 
 
 def force_serializer_instance(serializer):
@@ -29,27 +33,46 @@ def force_serializer_instance(serializer):
     return serializer
 
 
-class SwaggerAutoSchema(object):
-    body_methods = ('PUT', 'PATCH', 'POST')  #: methods allowed to have a request body
-
-    def __init__(self, view, path, method, overrides, components):
-        """Inspector class responsible for providing :class:`.Operation` definitions given a
+class BaseInspector(object):
+    def __init__(self, view, path, method, components):
+        """Base inspector
 
         :param view: the view associated with this endpoint
         :param str path: the path component of the operation URL
         :param str method: the http method of the operation
-        :param dict overrides: manual overrides as passed to :func:`@swagger_auto_schema <.swagger_auto_schema>`
         :param openapi.ReferenceResolver components: referenceable components
         """
-        super(SwaggerAutoSchema, self).__init__()
-        self._sch = AutoSchema()
         self.view = view
         self.path = path
         self.method = method
-        self.overrides = overrides
         self.components = components
-        self._sch.view = view
 
+    def probe_inspectors(self, inspectors, method_name, obj, **kwargs):
+        """Probe a list of inspectors with a given object. The first inspector in the list to return a value that
+        is not None wins.
+
+        :param list[type[BaseInspector]] inspectors: list of inspectors to probe
+        :param str method_name: name of the target method on the inspector
+        :param obj: first argument to inspector method
+        :param kwargs: additional arguments to inspector method
+        :return: the return value of the winning inspector, or ``None`` if no inspector handled the object
+        """
+        for inspector in inspectors:
+            assert hasattr(inspector, method_name), inspector.__name__ + " must implement " + method_name
+            assert inspect.isclass(inspector), "inspector must be a class, not an object"
+            assert issubclass(inspector, BaseInspector), "inspector must subclass of BaseInspector"
+
+            inspector = inspector(self.view, self.path, self.method, self.components)
+            method = getattr(inspector, method_name)
+            result = method(obj, **kwargs)
+            if result is not None:
+                return result
+
+        logger.warning("%s ignored because no inspector in %s handled it (operation: %s)", obj, inspectors, method_name)
+        return None
+
+
+class ViewInspector(BaseInspector):
     def get_operation(self, operation_keys):
         """Get an :class:`.Operation` for the given API endpoint (path, method).
         This includes query, body parameters and response schemas.
@@ -58,6 +81,175 @@ class SwaggerAutoSchema(object):
           e.g. ``('snippets', 'list')``, ``('snippets', 'retrieve')``, etc.
         :rtype: openapi.Operation
         """
+        raise NotImplementedError("ViewInspector must implement get_operation()!")
+
+
+class SerializerInspector(BaseInspector):
+    def get_schema(self, serializer):
+        """Convert a DRF Serializer instance to an :class:`.openapi.Schema`.
+
+        Should return ``None`` if this inspector does not know how to handle the given `serializer`.
+
+        :param serializers.BaseSerializer serializer: the ``Serializer`` instance
+        :rtype: openapi.Schema
+        """
+        return None
+
+    def get_request_parameters(self, serializer, in_):
+        """Convert a DRF serializer into a list of :class:`.Parameter`\ s.
+
+        Should return ``None`` if this inspector does not know how to handle the given `serializer`.
+
+        :param serializers.BaseSerializer serializer: the ``Serializer`` instance
+        :param str in_: the location of the parameters, one of the `openapi.IN_*` constants
+        :rtype: list[openapi.Parameter]
+        """
+        return None
+
+
+class InlineSerializerInspector(SerializerInspector):
+    """Provide serializer conversions using :func:`.serializer_field_to_swagger`."""
+    use_definitions = False
+
+    def get_schema(self, serializer):
+        definitions = self.components.with_scope(openapi.SCHEMA_DEFINITIONS) if self.use_definitions else None
+        return serializer_field_to_swagger(serializer, openapi.Schema, definitions)
+
+    def get_request_parameters(self, serializer, in_):
+        fields = getattr(serializer, 'fields', {})
+        return [
+            serializer_field_to_swagger(value, openapi.Parameter, name=key, in_=in_)
+            for key, value
+            in fields.items()
+        ]
+
+
+class ReferencingSerializerInspector(InlineSerializerInspector):
+    use_definitions = True
+
+
+class PaginatorInspector(BaseInspector):
+    def get_paginator_parameters(self, paginator):
+        """Get the pagination parameters for a single paginator **instance**.
+
+        Should return ``None`` if this inspector does not know how to handle the given `paginator`.
+
+        :param BasePagination paginator: the paginator
+        :rtype: list[openapi.Parameter]
+        """
+        return None
+
+    def get_paginated_response(self, paginator, response_schema):
+        """Add appropriate paging fields to a response :class:`.Schema`.
+
+        Should return ``None`` if this inspector does not know how to handle the given `paginator`.
+
+        :param BasePagination paginator: the paginator
+        :param openapi.Schema response_schema: the response schema that must be paged.
+        :rtype: openapi.Schema
+        """
+        return None
+
+
+class FilterInspector(BaseInspector):
+    def get_filter_parameters(self, filter_backend):
+        """Get the filter parameters for a single filter backend **instance**.
+
+        Should return ``None`` if this inspector does not know how to handle the given `filter_backend`.
+
+        :param BaseFilterBackend filter_backend: the filter backend
+        :rtype: list[openapi.Parameter]
+        """
+        return None
+
+
+class CoreAPICompatInspector(PaginatorInspector, FilterInspector):
+    """Converts ``coreapi.Field``\ s to :class:`.openapi.Parameter`\ s for filters and paginators that implement a
+    ``get_schema_fields`` method.
+    """
+    def get_paginator_parameters(self, paginator):
+        fields = []
+        if hasattr(paginator, 'get_schema_fields'):
+            fields = paginator.get_schema_fields(self.view)
+
+        return [self.coreapi_field_to_parameter(field) for field in fields]
+
+    def get_filter_parameters(self, filter_backend):
+        fields = []
+        if hasattr(filter_backend, 'get_schema_fields'):
+            fields = filter_backend.get_schema_fields(self.view)
+        return [self.coreapi_field_to_parameter(field) for field in fields]
+
+    def coreapi_field_to_parameter(self, field):
+        """Convert an instance of `coreapi.Field` to a swagger :class:`.Parameter` object.
+
+        :param coreapi.Field field:
+        :rtype: openapi.Parameter
+        """
+        location_to_in = {
+            'query': openapi.IN_QUERY,
+            'path': openapi.IN_PATH,
+            'form': openapi.IN_FORM,
+            'body': openapi.IN_FORM,
+        }
+        coreapi_types = {
+            coreschema.Integer: openapi.TYPE_INTEGER,
+            coreschema.Number: openapi.TYPE_NUMBER,
+            coreschema.String: openapi.TYPE_STRING,
+            coreschema.Boolean: openapi.TYPE_BOOLEAN,
+        }
+        return openapi.Parameter(
+            name=field.name,
+            in_=location_to_in[field.location],
+            type=coreapi_types.get(type(field.schema), openapi.TYPE_STRING),
+            required=field.required,
+            description=field.schema.description,
+        )
+
+
+class DjangoRestResponsePagination(PaginatorInspector):
+    """Provides response schema pagination warpping for django-rest-framework's LimitOffsetPagination,
+    PageNumberPagination and CursorPagination
+    """
+    def get_paginated_response(self, paginator, response_schema):
+        assert response_schema.type == openapi.TYPE_ARRAY, "array return expected for paged response"
+        paged_schema = None
+        if isinstance(paginator, (LimitOffsetPagination, PageNumberPagination, CursorPagination)):
+            paged_schema = openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    'next': openapi.Schema(type=openapi.TYPE_STRING, format=openapi.FORMAT_URI),
+                    'previous': openapi.Schema(type=openapi.TYPE_STRING, format=openapi.FORMAT_URI),
+                    'results': response_schema,
+                },
+                required=['count', 'results']
+            )
+
+            if not isinstance(paginator, CursorPagination):
+                paged_schema.properties['count'] = openapi.Schema(type=openapi.TYPE_INTEGER)
+
+        return paged_schema
+
+
+class SwaggerAutoSchema(ViewInspector):
+    body_methods = ('PUT', 'PATCH', 'POST')  #: methods allowed to have a request body
+
+    # TODO: add settings for these
+    serializer_inspectors = [ReferencingSerializerInspector]  #:
+    filter_inspectors = [CoreAPICompatInspector]  #:
+    paginator_inspectors = [DjangoRestResponsePagination, CoreAPICompatInspector]  #:
+
+    def __init__(self, view, path, method, overrides, components):
+        """Inspector class responsible for providing :class:`.Operation` definitions given a view, path and method.
+
+        :param dict overrides: manual overrides as passed to :func:`@swagger_auto_schema <.swagger_auto_schema>`
+        """
+        super(SwaggerAutoSchema, self).__init__(view, path, method, components)
+        self.overrides = overrides
+        self._sch = AutoSchema()
+        self._sch.view = view
+
+    def get_operation(self, operation_keys):
         consumes = self.get_consumes()
 
         body = self.get_request_body_parameters(consumes)
@@ -105,7 +297,7 @@ class SwaggerAutoSchema(object):
         else:
             if schema is None:
                 schema = self.get_request_body_schema(serializer)
-            return [self.make_body_parameter(schema)]
+            return [self.make_body_parameter(schema)] if schema is not None else []
 
     def get_view_serializer(self):
         """Return the serializer as defined by the view's ``get_serializer()`` method.
@@ -192,26 +384,6 @@ class SwaggerAutoSchema(object):
             responses=self.get_response_schemas(response_serializers)
         )
 
-    def get_paged_response_schema(self, response_schema):
-        """Add appropriate paging fields to a response :class:`.Schema`.
-
-        :param openapi.Schema response_schema: the response schema that must be paged.
-        :rtype: openapi.Schema
-        """
-        assert response_schema.type == openapi.TYPE_ARRAY, "array return expected for paged response"
-        paged_schema = openapi.Schema(
-            type=openapi.TYPE_OBJECT,
-            properties={
-                'count': openapi.Schema(type=openapi.TYPE_INTEGER),
-                'next': openapi.Schema(type=openapi.TYPE_STRING, format=openapi.FORMAT_URI),
-                'previous': openapi.Schema(type=openapi.TYPE_STRING, format=openapi.FORMAT_URI),
-                'results': response_schema,
-            },
-            required=['count', 'results']
-        )
-
-        return paged_schema
-
     def get_default_responses(self):
         """Get the default responses determined for this view from the request serializer and request method.
 
@@ -232,13 +404,14 @@ class SwaggerAutoSchema(object):
         default_schema = default_schema or ''
         if any(is_form_media_type(encoding) for encoding in self.get_consumes()):
             default_schema = ''
+        if default_schema and not isinstance(default_schema, openapi.Schema):
+            default_schema = self.serializer_to_schema(default_schema) or ''
+
         if default_schema:
-            if not isinstance(default_schema, openapi.Schema):
-                default_schema = self.serializer_to_schema(default_schema)
             if is_list_view(self.path, self.method, self.view) and self.method.lower() == 'get':
                 default_schema = openapi.Schema(type=openapi.TYPE_ARRAY, items=default_schema)
             if self.should_page():
-                default_schema = self.get_paged_response_schema(default_schema)
+                default_schema = self.get_paginated_response(default_schema) or default_schema
 
         return {str(default_status): default_schema}
 
@@ -341,17 +514,6 @@ class SwaggerAutoSchema(object):
 
         return is_list_view(self.path, self.method, self.view)
 
-    def get_filter_backend_parameters(self, filter_backend):
-        """Get the filter parameters for a single filter backend **instance**.
-
-        :param BaseFilterBackend filter_backend: the filter backend
-        :rtype: list[openapi.Parameter]
-        """
-        fields = []
-        if hasattr(filter_backend, 'get_schema_fields'):
-            fields = filter_backend.get_schema_fields(self.view)
-        return [self.coreapi_field_to_parameter(field) for field in fields]
-
     def get_filter_parameters(self):
         """Return the parameters added to the view by its filter backends.
 
@@ -362,7 +524,7 @@ class SwaggerAutoSchema(object):
 
         fields = []
         for filter_backend in self.view.filter_backends:
-            fields += self.get_filter_backend_parameters(filter_backend())
+            fields += self.probe_inspectors(self.filter_inspectors, 'get_filter_parameters', filter_backend()) or []
 
         return fields
 
@@ -382,18 +544,6 @@ class SwaggerAutoSchema(object):
 
         return is_list_view(self.path, self.method, self.view)
 
-    def get_paginator_parameters(self, paginator):
-        """Get the pagination parameters for a single paginator **instance**.
-
-        :param BasePagination paginator: the paginator
-        :rtype: list[openapi.Parameter]
-        """
-        fields = []
-        if hasattr(paginator, 'get_schema_fields'):
-            fields = paginator.get_schema_fields(self.view)
-
-        return [self.coreapi_field_to_parameter(field) for field in fields]
-
     def get_pagination_parameters(self):
         """Return the parameters added to the view by its paginator.
 
@@ -402,7 +552,7 @@ class SwaggerAutoSchema(object):
         if not self.should_page():
             return []
 
-        return self.get_paginator_parameters(self.view.paginator)
+        return self.probe_inspectors(self.paginator_inspectors, 'get_paginator_parameters', self.view.paginator) or []
 
     def get_description(self):
         """Return an operation description determined as appropriate from the view's method and class docstrings.
@@ -426,60 +576,29 @@ class SwaggerAutoSchema(object):
         return media_types[:1]
 
     def serializer_to_schema(self, serializer):
-        """Convert a DRF Serializer instance to an :class:`.openapi.Schema`.
+        """Convert a serializer to an OpenAPI :class:`.Schema`.
 
         :param serializers.BaseSerializer serializer: the ``Serializer`` instance
-        :rtype: openapi.Schema
+        :returns: the converted :class:`.Schema`, or ``None`` in case of an unknown serializer
+        :rtype: openapi.Schema,openapi.SchemaRef,None
         """
-        definitions = self.components.with_scope(openapi.SCHEMA_DEFINITIONS)
-        return serializer_field_to_swagger(serializer, openapi.Schema, definitions)
+        return self.probe_inspectors(self.serializer_inspectors, 'get_schema', serializer)
 
     def serializer_to_parameters(self, serializer, in_):
-        """Convert a DRF serializer into a list of :class:`.Parameter`\ s using :meth:`.field_to_parameter`
+        """Convert a serializer to a possibly empty list of :class:`.Parameter`\ s.
 
         :param serializers.BaseSerializer serializer: the ``Serializer`` instance
         :param str in_: the location of the parameters, one of the `openapi.IN_*` constants
         :rtype: list[openapi.Parameter]
         """
-        fields = getattr(serializer, 'fields', {})
-        return [
-            self.field_to_parameter(value, key, in_)
-            for key, value
-            in fields.items()
-        ]
+        return self.probe_inspectors(self.serializer_inspectors, 'get_request_parameters', serializer, in_=in_) or []
 
-    def field_to_parameter(self, field, name, in_):
-        """Convert a DRF serializer Field to a swagger :class:`.Parameter` object.
+    def get_paginated_response(self, response_schema):
+        """Add appropriate paging fields to a response :class:`.Schema`.
 
-        :param coreapi.Field field:
-        :param str name: the name of the parameter
-        :param str in_: the location of the parameter, one of the `openapi.IN_*` constants
-        :rtype: openapi.Parameter
+        :param openapi.Schema response_schema: the response schema that must be paged.
+        :returns: the paginated response class:`.Schema`, or ``None`` in case of an unknown pagination scheme
+        :rtype: openapi.Schema
         """
-        return serializer_field_to_swagger(field, openapi.Parameter, name=name, in_=in_)
-
-    def coreapi_field_to_parameter(self, field):
-        """Convert an instance of `coreapi.Field` to a swagger :class:`.Parameter` object.
-
-        :param coreapi.Field field:
-        :rtype: openapi.Parameter
-        """
-        location_to_in = {
-            'query': openapi.IN_QUERY,
-            'path': openapi.IN_PATH,
-            'form': openapi.IN_FORM,
-            'body': openapi.IN_FORM,
-        }
-        coreapi_types = {
-            coreschema.Integer: openapi.TYPE_INTEGER,
-            coreschema.Number: openapi.TYPE_NUMBER,
-            coreschema.String: openapi.TYPE_STRING,
-            coreschema.Boolean: openapi.TYPE_BOOLEAN,
-        }
-        return openapi.Parameter(
-            name=field.name,
-            in_=location_to_in[field.location],
-            type=coreapi_types.get(type(field.schema), openapi.TYPE_STRING),
-            required=field.required,
-            description=field.schema.description,
-        )
+        return self.probe_inspectors(self.paginator_inspectors, 'get_paginated_response',
+                                     self.view.paginator, response_schema=response_schema)

--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -294,7 +294,7 @@ class PathItem(SwaggerDict):
 
 class Operation(SwaggerDict):
     def __init__(self, operation_id, responses, parameters=None, consumes=None,
-                 produces=None, description=None, tags=None, **extra):
+                 produces=None, summary=None, description=None, tags=None, **extra):
         """Information about an API operation (path + http method combination)
 
         :param str operation_id: operation ID, should be unique across all operations
@@ -302,11 +302,13 @@ class Operation(SwaggerDict):
         :param list[.Parameter] parameters: parameters accepted
         :param list[str] consumes: content types accepted
         :param list[str] produces: content types produced
-        :param str description: operation description
+        :param str summary: operation summary; should be < 120 characters
+        :param str description: operation description; can be of any length and supports markdown
         :param list[str] tags: operation tags
         """
         super(Operation, self).__init__(**extra)
         self.operation_id = operation_id
+        self.summary = summary
         self.description = description
         self.parameters = filter_none(parameters)
         self.responses = responses
@@ -499,7 +501,7 @@ class ReferenceResolver(object):
             self._objects[scope] = OrderedDict()
 
     def with_scope(self, scope):
-        """Return a new :class:`.ReferenceResolver` whose scope is defaulted and forced to `scope`.
+        """Return a view into this :class:`.ReferenceResolver` whose scope is defaulted and forced to `scope`.
 
         :param str scope: target scope, must be in this resolver's `scopes`
         :return: the bound resolver

--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -61,6 +61,24 @@ def make_swagger_name(attribute_name):
     return camelize(attribute_name.rstrip('_'), uppercase_first_letter=False)
 
 
+def filter_none(obj):
+    """Remove ``None`` values from tuples, lists or dictionaries. Return other objects as-is.
+
+    :param obj:
+    :return: collection with ``None`` values removed
+    """
+    if obj is None:
+        return None
+    new_obj = None
+    if isinstance(obj, dict):
+        new_obj = type(obj)((k, v) for k, v in obj.items() if k is not None and v is not None)
+    if isinstance(obj, (list, tuple)):
+        new_obj = type(obj)(v for v in obj if v is not None)
+    if new_obj is not None and len(new_obj) != len(obj):
+        return new_obj
+    return obj
+
+
 def _bare_SwaggerDict(cls):
     assert issubclass(cls, SwaggerDict)
     result = cls.__new__(cls)
@@ -230,7 +248,7 @@ class Swagger(SwaggerDict):
         self.base_path = '/'
 
         self.paths = paths
-        self.definitions = definitions
+        self.definitions = filter_none(definitions)
         self._insert_extras__()
 
 
@@ -270,7 +288,7 @@ class PathItem(SwaggerDict):
         self.patch = patch
         self.delete = delete
         self.options = options
-        self.parameters = parameters
+        self.parameters = filter_none(parameters)
         self._insert_extras__()
 
 
@@ -290,11 +308,11 @@ class Operation(SwaggerDict):
         super(Operation, self).__init__(**extra)
         self.operation_id = operation_id
         self.description = description
-        self.parameters = [param for param in parameters if param is not None]
+        self.parameters = filter_none(parameters)
         self.responses = responses
-        self.consumes = consumes
-        self.produces = produces
-        self.tags = tags
+        self.consumes = filter_none(consumes)
+        self.produces = filter_none(produces)
+        self.tags = filter_none(tags)
         self._insert_extras__()
 
 
@@ -373,9 +391,9 @@ class Schema(SwaggerDict):
             raise AssertionError(
                 "the `requires` attribute of schema must be an array of required properties, not a boolean!")
         self.description = description
-        self.required = required
+        self.required = filter_none(required)
         self.type = type
-        self.properties = properties
+        self.properties = filter_none(properties)
         self.additional_properties = additional_properties
         self.format = format
         self.enum = enum

--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -47,7 +47,8 @@ def is_list_view(path, method, view):
 
 
 def swagger_auto_schema(method=None, methods=None, auto_schema=None, request_body=None, query_serializer=None,
-                        manual_parameters=None, operation_description=None, responses=None):
+                        manual_parameters=None, operation_id=None, operation_description=None, responses=None,
+                        serializer_inspectors=None, filter_inspectors=None, paginator_inspectors=None):
     """Decorate a view method to customize the :class:`.Operation` object generated from it.
 
     `method` and `methods` are mutually exclusive and must only be present when decorating a view method that accepts
@@ -84,6 +85,7 @@ def swagger_auto_schema(method=None, methods=None, auto_schema=None, request_bod
 
         It is an error to supply ``form`` parameters when the request does not consume form-data.
 
+    :param str operation_id: operation ID override; the operation ID must be unique accross the whole API
     :param str operation_description: operation description override
     :param dict[str,(.Schema,.SchemaRef,.Response,str,Serializer)] responses: a dict of documented manual responses
         keyed on response status code. If no success (``2xx``) response is given, one will automatically be
@@ -98,6 +100,12 @@ def swagger_auto_schema(method=None, methods=None, auto_schema=None, request_bod
         * a :class:`.Response` object will be used as-is; however if its ``schema`` attribute is a ``Serializer``,
           it will automatically be converted into a :class:`.Schema`
 
+    :param list[.SerializerInspector] serializer_inspectors: extra serializer inspectors;
+        these will be tried before :attr:`.serializer_inspectors` on the :class:`.SwaggerAutoSchema` instance
+    :param list[.FilterInspector] filter_inspectors: extra filter inspectors;
+        these will be tried before :attr:`.filter_inspectors` on the :class:`.SwaggerAutoSchema` instance
+    :param list[.PaginatorInspector] paginator_inspectors: extra paginator inspectors;
+        these will be tried before :attr:`.paginator_inspectors` on the :class:`.SwaggerAutoSchema` instance
     """
 
     def decorator(view_method):
@@ -106,8 +114,12 @@ def swagger_auto_schema(method=None, methods=None, auto_schema=None, request_bod
             'request_body': request_body,
             'query_serializer': query_serializer,
             'manual_parameters': manual_parameters,
+            'operation_id': operation_id,
             'operation_description': operation_description,
             'responses': responses,
+            'filter_inspectors': list(filter_inspectors) if filter_inspectors else None,
+            'paginator_inspectors': list(paginator_inspectors) if filter_inspectors else None,
+            'serializer_inspectors': list(serializer_inspectors) if serializer_inspectors else None,
         }
         data = {k: v for k, v in data.items() if v is not None}
 
@@ -120,7 +132,7 @@ def swagger_auto_schema(method=None, methods=None, auto_schema=None, request_bod
             # detail_route, list_route or api_view
             assert bool(http_method_names) != bool(bind_to_methods), "this should never happen"
             available_methods = http_method_names + bind_to_methods
-            existing_data = getattr(view_method, 'swagger_auto_schema', {})
+            existing_data = getattr(view_method, '_swagger_auto_schema', {})
 
             if http_method_names:
                 _route = "api_view"
@@ -145,12 +157,12 @@ def swagger_auto_schema(method=None, methods=None, auto_schema=None, request_bod
                 existing_data.update((mth.lower(), data) for mth in _methods)
             else:
                 existing_data[available_methods[0]] = data
-            view_method.swagger_auto_schema = existing_data
+            view_method._swagger_auto_schema = existing_data
         else:
             assert method is None and methods is None, \
                 "the methods argument should only be specified when decorating a detail_route or list_route; you " \
                 "should also ensure that you put the swagger_auto_schema decorator AFTER (above) the _route decorator"
-            view_method.swagger_auto_schema = data
+            view_method._swagger_auto_schema = data
 
         return view_method
 

--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -162,7 +162,7 @@ def serializer_field_to_swagger(field, swagger_object_type, definitions=None, **
 
     :param rest_framework.serializers.Field field: the source field
     :param type[openapi.SwaggerDict] swagger_object_type: should be one of Schema, Parameter, Items
-    :param .ReferenceResolver definitions: used to serialize Schemas by reference
+    :param .ReferenceResolver definitions: optional, used to serialize Schemas by reference
     :param kwargs: extra attributes for constructing the object;
        if swagger_object_type is Parameter, ``name`` and ``in_`` should be provided
     :return: the swagger object
@@ -202,7 +202,6 @@ def serializer_field_to_swagger(field, swagger_object_type, definitions=None, **
     elif isinstance(field, serializers.Serializer):
         if swagger_object_type != openapi.Schema:
             raise SwaggerGenerationError("cannot instantiate nested serializer as " + swagger_object_type.__name__)
-        assert definitions is not None, "ReferenceResolver required when instantiating Schema"
 
         serializer = field
         if hasattr(serializer, '__ref_name__'):
@@ -226,7 +225,7 @@ def serializer_field_to_swagger(field, swagger_object_type, definitions=None, **
                 required=required or None,
             )
 
-        if not ref_name:
+        if not ref_name or definitions is None:
             return make_schema_definition()
 
         definitions.setdefault(ref_name, make_schema_definition)

--- a/testproj/users/views.py
+++ b/testproj/users/views.py
@@ -32,7 +32,7 @@ class UserList(APIView):
         serializer.save()
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-    @swagger_auto_schema(request_body=no_body, operation_description="dummy operation")
+    @swagger_auto_schema(request_body=no_body, operation_id="users_dummy", operation_description="dummy operation")
     def patch(self, request):
         pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,12 @@
 import copy
 import json
 import os
+from collections import OrderedDict
 
 import pytest
-from ruamel import yaml
 
 from drf_yasg import openapi, codecs
+from drf_yasg.codecs import yaml_sane_load
 from drf_yasg.generators import OpenAPISchemaGenerator
 
 
@@ -36,7 +37,7 @@ def swagger(generator):
 def swagger_dict(generator):
     swagger = generator.get_schema(None, True)
     json_bytes = codec_json().encode(swagger)
-    return json.loads(json_bytes.decode('utf-8'))
+    return json.loads(json_bytes.decode('utf-8'), object_pairs_hook=OrderedDict)
 
 
 @pytest.fixture
@@ -68,4 +69,4 @@ def redoc_settings(settings):
 @pytest.fixture
 def reference_schema():
     with open(os.path.join(os.path.dirname(__file__), 'reference.yaml')) as reference:
-        return yaml.safe_load(reference)
+        return yaml_sane_load(reference)

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -495,8 +495,8 @@ definitions:
         format: uuid
       cover:
         type: string
-        format: uri
         readOnly: true
+        format: uri
       cover_name:
         type: string
         readOnly: true

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -402,7 +402,7 @@ paths:
       tags:
         - users
     patch:
-      operationId: users_partial_update
+      operationId: users_dummy
       description: dummy operation
       parameters: []
       responses:

--- a/tests/test_reference_schema.py
+++ b/tests/test_reference_schema.py
@@ -1,13 +1,24 @@
+from collections import OrderedDict
+
 from datadiff.tools import assert_equal
+
+from drf_yasg.codecs import yaml_sane_dump
 
 
 def test_reference_schema(swagger_dict, reference_schema):
     # formatted better than pytest diff
-    swagger_dict = dict(swagger_dict)
-    reference_schema = dict(reference_schema)
+    swagger_dict = OrderedDict(swagger_dict)
+    reference_schema = OrderedDict(reference_schema)
     ignore = ['info', 'host', 'schemes', 'basePath', 'securityDefinitions']
     for attr in ignore:
         swagger_dict.pop(attr, None)
         reference_schema.pop(attr, None)
 
-    assert_equal(swagger_dict, reference_schema)
+    try:
+        assert_equal(swagger_dict, reference_schema)
+    except AssertionError as e:
+        if str(e).isspace():
+            # ordering difference, print diff between strings
+            assert_equal(yaml_sane_dump(swagger_dict, binary=False), yaml_sane_dump(reference_schema, binary=False))
+        else:
+            raise

--- a/tests/test_schema_generator.py
+++ b/tests/test_schema_generator.py
@@ -1,9 +1,10 @@
 import json
+from collections import OrderedDict
 
 import pytest
-from ruamel import yaml
 
 from drf_yasg import openapi, codecs
+from drf_yasg.codecs import yaml_sane_load
 from drf_yasg.generators import OpenAPISchemaGenerator
 
 
@@ -42,13 +43,13 @@ def test_yaml_codec_roundtrip(codec_yaml, generator, validate_schema):
     yaml_bytes = codec_yaml.encode(swagger)
     assert b'omap' not in yaml_bytes  # ensure no ugly !!omap is outputted
     assert b'&id' not in yaml_bytes and b'*id' not in yaml_bytes  # ensure no YAML references are generated
-    validate_schema(yaml.safe_load(yaml_bytes.decode('utf-8')))
+    validate_schema(yaml_sane_load(yaml_bytes.decode('utf-8')))
 
 
 def test_yaml_and_json_match(codec_yaml, codec_json, generator):
     swagger = generator.get_schema(None, True)
-    yaml_schema = yaml.safe_load(codec_yaml.encode(swagger).decode('utf-8'))
-    json_schema = json.loads(codec_json.encode(swagger).decode('utf-8'))
+    yaml_schema = yaml_sane_load(codec_yaml.encode(swagger).decode('utf-8'))
+    json_schema = json.loads(codec_json.encode(swagger).decode('utf-8'), object_pairs_hook=OrderedDict)
     assert yaml_schema == json_schema
 
 

--- a/tests/test_schema_views.py
+++ b/tests/test_schema_views.py
@@ -2,7 +2,8 @@ import json
 from collections import OrderedDict
 
 import pytest
-from ruamel import yaml
+
+from drf_yasg.codecs import yaml_sane_load
 
 
 def _validate_text_schema_view(client, validate_schema, path, loader):
@@ -22,7 +23,7 @@ def test_swagger_json(client, validate_schema):
 
 
 def test_swagger_yaml(client, validate_schema):
-    _validate_text_schema_view(client, validate_schema, "/swagger.yaml", yaml.safe_load)
+    _validate_text_schema_view(client, validate_schema, "/swagger.yaml", yaml_sane_load)
 
 
 def test_exception_middleware(client, swagger_settings):
@@ -70,5 +71,5 @@ def test_caching(client, validate_schema):
 @pytest.mark.urls('urlconfs.non_public_urls')
 def test_non_public(client):
     response = client.get('/private/swagger.yaml')
-    swagger = yaml.safe_load(response.content.decode('utf-8'))
+    swagger = yaml_sane_load(response.content.decode('utf-8'))
     assert len(swagger['paths']) == 0


### PR DESCRIPTION
Information about serializers, filters and paginators is now gathered via specialised *Inspector classes. This should allow for easier implementation of cases where one wants to add support for specific external components.