### PR TITLE
Pass context when instanciating a serializer

### DIFF
--- a/src/drf_yasg/inspectors.py
+++ b/src/drf_yasg/inspectors.py
@@ -114,7 +114,8 @@ class SwaggerAutoSchema(object):
         """
         if not hasattr(self.view, 'get_serializer'):
             return None
-        return self.view.get_serializer()
+        kwargs = {'context': self.view.get_serializer_context()}
+        return self.view.get_serializer(**kwargs)
 
     def get_request_serializer(self):
         """Return the request serializer (used for parsing the request payload) for this endpoint.


### PR DESCRIPTION
Hi,
Thank you for this project, I'm very impressed.

Some of our serializers needs the request to render properly, this change aim to fix that.

The patch is inspired by DRF itself.
https://github.com/encode/django-rest-framework/blob/master/rest_framework/generics.py#L111