### PR TITLE
Run Django 1.11 along with Django 2.0 in travis for python 3.x

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 source = drf_yasg
 branch = True
 parallel = true
+disable_warnings = module-not-measured
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 source = drf_yasg
 branch = True
+parallel = true
 
 [report]
 # Regexes for lines to exclude from consideration
@@ -29,7 +30,8 @@ exclude_lines =
     raise SwaggerGenerationError
 
 ignore_errors = True
-precision = 0
+precision = 2
+show_missing = True
 
 [paths]
 source =

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,17 +45,27 @@ install:
  - pip install -r requirements/ci.txt
 
 before_script:
- - 'coverage erase'
- - '[[ -z "$TOXENV" ]] && REPORT_COVERAGE=1'
- - '[[ -z "$TOXENV" && ! -z "$DRF" && "$DRF" != "master" ]] && USE_DETOX=1'
+ - coverage erase
+ - |
+  if [[ -z "$TOXENV" ]]
+  then
+    REPORT_COVERAGE="yes"
+    echo "Reporting coverage: ${REPORT_COVERAGE}
+  fi
+ - |
+  if [[ -z "$TOXENV" && ! -z "$DRF" && "$DRF" != "master" ]]
+  then
+    USE_DETOX="yes"
+    echo "Using detox: ${USE_DETOX}'
+  fi
 
 script:
- - 'if [[ $USE_DETOX == 1 ]]; then detox; else tox; fi'
+ - 'if [[ "$USE_DETOX" == "yes" ]]; then detox; else tox; fi'
 
 after_success:
- - 'coverage combine'
- - 'if [[ $REPORT_COVERAGE == 1 ]]; then coverage report; fi'
- - 'if [[ $REPORT_COVERAGE == 1 ]]; then codecov; fi'
+ - coverage combine
+ - 'if [[ "$REPORT_COVERAGE" == "yes" ]]; then coverage report; fi'
+ - 'if [[ "$REPORT_COVERAGE" == "yes" ]]; then codecov; fi'
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ jobs:
 
     - stage: publish
       python: '3.6'
+      before_script: skip
       script: skip
+      after_success: skip
       env:
       deploy: &pypi
         provider: pypi
@@ -47,9 +49,11 @@ install:
 before_script:
  - coverage erase
  - |
-  [[ -z "$TOXENV" ]] && REPORT_COVERAGE="yes" && echo "Reporting coverage: ${REPORT_COVERAGE}" || true
+  [[ -z "$TOXENV" ]] && REPORT_COVERAGE="yes" || REPORT_COVERAGE="no";
+  echo "Reporting coverage: ${REPORT_COVERAGE}"
  - |
-  [[ -z "$TOXENV" && ! -z "$DRF" && "$DRF" != "master" ]] && USE_DETOX="yes" &&echo "Using detox: ${USE_DETOX}" || true
+  [[ -z "$TOXENV" && ! -z "$DRF" && "$DRF" != "master" ]] && USE_DETOX="yes" || USE_DETOX="no";
+  echo "Using detox: ${USE_DETOX}"
 
 script:
  - 'if [[ "$USE_DETOX" == "yes" ]]; then detox; else tox; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,18 @@ jobs:
   include:
     - stage: test
       python: '3.5'
+      script: tox
+      after_success: skip
       env: TOXENV=docs
     -
       python: '2.7'
+      script: tox
+      after_success: skip
       env: TOXENV=lint
     -
       python: '3.6'
+      script: tox
+      after_success: skip
       env: DRF=master
 
     - stage: publish

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,17 @@ language: python
 cache: pip
 
 python:
+ - '2.7'
  - '3.4'
  - '3.5'
  - '3.6'
 
 env:
- - DRF=3.7 DJANGO=2.0
+ - DRF=3.7
 
 jobs:
   include:
     - stage: test
-      python: '2.7'
-      env: DRF=3.7 DJANGO=1.11
-    -
       python: '3.5'
       env: TOXENV=docs
     -
@@ -50,7 +48,7 @@ before_script:
  - coverage erase
 
 script:
- - tox
+ - detox
 
 after_success:
  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,19 @@ jobs:
     - stage: test
       python: '3.5'
       script: tox
+      after_script: skip
       after_success: skip
       env: TOXENV=docs
     -
       python: '2.7'
       script: tox
+      after_script: skip
       after_success: skip
       env: TOXENV=lint
     -
       python: '3.6'
       script: tox
+      after_script: skip
       after_success: skip
       env: DRF=master
 
@@ -55,6 +58,9 @@ before_script:
 
 script:
  - detox
+
+after_script:
+ - coverage combine && coverage report
 
 after_success:
  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,23 +13,14 @@ env:
 jobs:
   include:
     - stage: test
+      python: '3.6'
+      env: DRF=master
+    -
       python: '3.5'
-      script: tox
-      after_script: skip
-      after_success: skip
       env: TOXENV=docs
     -
       python: '2.7'
-      script: tox
-      after_script: skip
-      after_success: skip
       env: TOXENV=lint
-    -
-      python: '3.6'
-      script: tox
-      after_script: skip
-      after_success: skip
-      env: DRF=master
 
     - stage: publish
       python: '3.6'
@@ -54,16 +45,17 @@ install:
  - pip install -r requirements/ci.txt
 
 before_script:
- - coverage erase
+ - 'coverage erase'
+ - '[[ -z "$TOXENV" ]] && REPORT_COVERAGE=1'
+ - '[[ -z "$TOXENV" && ! -z "$DRF" && "$DRF" != "master" ]] && USE_DETOX=1'
 
 script:
- - detox
-
-after_script:
- - coverage combine && coverage report
+ - 'if [[ $USE_DETOX == 1 ]]; then detox; else tox; fi'
 
 after_success:
- - codecov
+ - 'coverage combine'
+ - 'if [[ $REPORT_COVERAGE == 1 ]]; then coverage report; fi'
+ - 'if [[ $REPORT_COVERAGE == 1 ]]; then codecov; fi'
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,17 +47,9 @@ install:
 before_script:
  - coverage erase
  - |
-  if [[ -z "$TOXENV" ]]
-  then
-    REPORT_COVERAGE="yes"
-    echo "Reporting coverage: ${REPORT_COVERAGE}
-  fi
+  [[ -z "$TOXENV" ]] && REPORT_COVERAGE="yes" && echo "Reporting coverage: ${REPORT_COVERAGE}" || true
  - |
-  if [[ -z "$TOXENV" && ! -z "$DRF" && "$DRF" != "master" ]]
-  then
-    USE_DETOX="yes"
-    echo "Using detox: ${USE_DETOX}'
-  fi
+  [[ -z "$TOXENV" && ! -z "$DRF" && "$DRF" != "master" ]] && USE_DETOX="yes" &&echo "Using detox: ${USE_DETOX}" || true
 
 script:
  - 'if [[ "$USE_DETOX" == "yes" ]]; then detox; else tox; fi'

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,4 +4,3 @@
 -r lint.txt
 
 tox-battery>=0.5
-detox>=0.11

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,7 @@
 pytest>=2.9
 pytest-pythonpath>=0.7.1
 pytest-cov>=2.5.1
+pytest-xdist>=1.22.0
 # latest pip version of pytest-django is more than a year old and does not support Django 2.0
 git+https://github.com/pytest-dev/pytest-django.git@94cccb956435dd7a719606744ee7608397e1eafb
 datadiff==2.0.0

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -1,4 +1,5 @@
 # requirements for building and running tox
 tox>=2.9.1
+detox>=0.11
 
 -r setup.txt

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     -rrequirements/test.txt
 
 commands =
-    pytest --cov-config .coveragerc --cov-append --cov {posargs}
+    pytest --cov-config .coveragerc --cov-append --no-cov-on-fail --cov {posargs}
 
 [testenv:py36-drfmaster]
 pip_pre = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-django111-drf37,
-    py{34,35,36}-django20-drf37,
+    py{34,35,36}-django{111,20}-drf37,
     py36-drfmaster,
     lint, docs
 
@@ -9,9 +9,6 @@ envlist =
 DRF =
     3.7: drf37
     master: drfmaster
-DJANGO =
-    1.11: django111
-    2.0: django20
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ commands =
 [pytest]
 DJANGO_SETTINGS_MODULE = testproj.settings.local
 python_paths = testproj
+addopts = -n 3
 
 [flake8]
 max-line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     -rrequirements/test.txt
 
 commands =
-    pytest --cov= --cov-config .coveragerc --cov-append --cov-report= {posargs}
+    pytest --cov --cov-config .coveragerc --cov-append --cov-report="" {posargs}
 
 [testenv:py36-drfmaster]
 pip_pre = True

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     -rrequirements/test.txt
 
 commands =
-    pytest --cov-config .coveragerc --cov-append --no-cov-on-fail --cov {posargs}
+    pytest --cov= --cov-config .coveragerc --cov-append --cov-report= {posargs}
 
 [testenv:py36-drfmaster]
 pip_pre = True


### PR DESCRIPTION
Runs Django 1.11 and 2.0 for each 3.x version with detox in the same Travis job for minimal performance impact.