### PR TITLE
Make 1.10.0 the min six version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ openapi_codec>=1.3.2
 ruamel.yaml>=0.15.34
 inflection>=0.3.1
 future>=0.16.0
-six>=1.11.0
+six>=1.10.0
 uritemplate>=3.0.0
 
 djangorestframework>=3.7.7


### PR DESCRIPTION
I believe some projects could have transitive dependency conflicts with only supporting the latest version of six. So, what about supporting the previous version? I tested it locally and tests passed on some python versions. I think they'll all pass.