### PR TITLE
Fix in-place modification of swagger_auto_schema arguments

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,15 @@ Changelog
 
 
 *********
+**1.4.5**
+*********
+
+*Release date: Mar 05, 2018*
+
+- **FIXED:** fixed an issue with modification of ``swagger_auto_schema`` arguments in-place during introspection, which
+  would sometimes cause an incomplete Swagger document to be generated after the first pass (:issue:`74`, :pr:`75`)
+
+*********
 **1.4.4**
 *********
 

--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import re
 from collections import OrderedDict, defaultdict
@@ -388,7 +389,7 @@ class OpenAPISchemaGenerator(object):
         if method in overrides:
             overrides = overrides[method]
 
-        return overrides
+        return copy.deepcopy(overrides)
 
     def get_path_parameters(self, path, view_cls):
         """Return a list of Parameter instances corresponding to any templated path variables.

--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -11,10 +11,15 @@ from rest_framework.views import APIView
 
 logger = logging.getLogger(__name__)
 
-#: used to forcibly remove the body of a request via :func:`.swagger_auto_schema`
-no_body = object()
 
-unset = object()
+class no_body(object):
+    """Used as a sentinel value to forcibly remove the body of a request via :func:`.swagger_auto_schema`."""
+    pass
+
+
+class unset(object):
+    """Used as a sentinel value for function parameters not set by the caller where ``None`` would be a valid value."""
+    pass
 
 
 def swagger_auto_schema(method=None, methods=None, auto_schema=unset, request_body=None, query_serializer=None,
@@ -33,7 +38,7 @@ def swagger_auto_schema(method=None, methods=None, auto_schema=unset, request_bo
     :param .inspectors.SwaggerAutoSchema auto_schema: custom class to use for generating the Operation object;
         this overrides both the class-level ``swagger_schema`` attribute and the ``DEFAULT_AUTO_SCHEMA_CLASS``
         setting, and can be set to ``None`` to prevent this operation from being generated
-    :param .Schema,.SchemaRef,.Serializer request_body: custom request body, or :data:`.no_body`. The value given here
+    :param .Schema,.SchemaRef,.Serializer request_body: custom request body, or :class:`.no_body`. The value given here
         will be used as the ``schema`` property of a :class:`.Parameter` with ``in: 'body'``.
 
         A Schema or SchemaRef is not valid if this request consumes form-data, because ``form`` and ``body`` parameters


### PR DESCRIPTION
In-place modification of override arguments (for example [here](https://github.com/axnsan12/drf-yasg/blob/ee46f59fb1ee8b3ed9d0743851e7773c2d09e350/src/drf_yasg/inspectors/view.py#L226)) could sometimes cause parts of the document to not be generated on subsequent calls to ``OpenAPISchemaGenerator.get_schema``. This pull request fixes the problem by calling ``copy.deepcopy`` on overrides before passing them to inspectors.

Fixes #74.