### PR TITLE
Fix URL in the example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ In ``urls.py``:
    )
 
    urlpatterns = [
-      url(r'^swagger(?P<format>.json|.yaml)$', schema_view.without_ui(cache_timeout=None), name='schema-json'),
+      url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=None), name='schema-json'),
       url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=None), name='schema-swagger-ui'),
       url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=None), name='schema-redoc'),
       ...


### PR DESCRIPTION
Django's URLs are regexes, thus the character '.' is used as a joker, making `r'^swagger(?P<format>.json|.yaml)$'` accept not only `swagger.json` and `swagger.xml` but any URL replacing the '.' with a single other character, leading to a TypeError: ```Expected a `openapi.Swagger` instance```.
Simply escape this character to fix the "issue"