### PR TITLE
Adding SUPPORTED_SUBMIT_METHODS swagger ui setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -276,6 +276,15 @@ to the ``SwaggerUIBundle#initOAuth`` method, and must be a dictionary. See
 
 **Default**: :python:`{}`
 
+SUPPORTED_SUBMIT_METHODS
+------------------------
+
+List of HTTP methods that have the Try it out feature enabled. An empty array disables Try it out for all operations.
+This does not filter the operations from the display.
+
+**Default**: :python:`['get','put','post','delete','options','head','patch','trace']` |br|
+*Maps to parameter*: ``supportedSubmitMethods``
+
 ******************
 ``REDOC_SETTINGS``
 ******************

--- a/src/drf_yasg/app_settings.py
+++ b/src/drf_yasg/app_settings.py
@@ -46,6 +46,16 @@ SWAGGER_DEFAULTS = {
     'DEFAULT_MODEL_DEPTH': 3,
     'OAUTH2_REDIRECT_URL': None,
     'OAUTH2_CONFIG': {},
+    'SUPPORTED_SUBMIT_METHODS': [
+        'get',
+        'put',
+        'post',
+        'delete',
+        'options',
+        'head',
+        'patch',
+        'trace'
+    ],
 }
 
 REDOC_DEFAULTS = {

--- a/src/drf_yasg/renderers.py
+++ b/src/drf_yasg/renderers.py
@@ -94,6 +94,7 @@ class _UIRenderer(BaseRenderer):
             'defaultModelExpandDepth': swagger_settings.DEFAULT_MODEL_DEPTH,
             'defaultModelsExpandDepth': swagger_settings.DEFAULT_MODEL_DEPTH,
             'oauth2RedirectUrl': swagger_settings.OAUTH2_REDIRECT_URL,
+            'supportedSubmitMethods': swagger_settings.SUPPORTED_SUBMIT_METHODS,
         }
         data = {k: v for k, v in data.items() if v is not None}
         if swagger_settings.VALIDATOR_URL != '':


### PR DESCRIPTION
Adding supportedSubmitMethods config option which was recently added to swagger-ui 3.x under following pull request.
https://github.com/swagger-api/swagger-ui/pull/4186
Default value is ["get", "put", "post", "delete", "options", "head", "patch", "trace"]