### PR TITLE
Make parameters order stable for multi-parameter URLs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 
 
 *********
+**1.6.2**
+*********
+
+*Release date: TODO, 2018*
+
+- **FIXED:** made documentation ordering of parameters stable for urls with multiple parameters (:issue:`105`, :pr:`106`)
+
+*********
 **1.6.1**
 *********
 

--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -403,7 +403,7 @@ class OpenAPISchemaGenerator(object):
         queryset = getattr(view_cls, 'queryset', None)
         model = getattr(getattr(view_cls, 'queryset', None), 'model', None)
 
-        for variable in uritemplate.variables(path):
+        for variable in sorted(uritemplate.variables(path)):
             model, model_field = get_queryset_field(queryset, variable)
             attrs = get_basic_type_info(model_field) or {'type': openapi.TYPE_STRING}
             if getattr(view_cls, 'lookup_field', None) == variable and attrs['type'] == openapi.TYPE_STRING:

--- a/testproj/todo/urls.py
+++ b/testproj/todo/urls.py
@@ -1,3 +1,4 @@
+from django.conf.urls import url
 from rest_framework import routers
 
 from todo import views
@@ -8,3 +9,8 @@ router.register(r'another', views.TodoAnotherViewSet)
 router.register(r'yetanother', views.TodoYetAnotherViewSet)
 
 urlpatterns = router.urls
+
+urlpatterns += [
+    url(r'^(?P<todo_id>\d+)/yetanother/(?P<yetanother_id>\d+)/$',
+        views.NestedTodoView.as_view(),),
+]

--- a/testproj/todo/views.py
+++ b/testproj/todo/views.py
@@ -1,4 +1,5 @@
 from rest_framework import viewsets
+from rest_framework.generics import RetrieveAPIView
 
 from .models import Todo, TodoAnother, TodoYetAnother
 from .serializer import TodoAnotherSerializer, TodoSerializer, TodoYetAnotherSerializer
@@ -19,4 +20,8 @@ class TodoAnotherViewSet(viewsets.ReadOnlyModelViewSet):
 
 class TodoYetAnotherViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = TodoYetAnother.objects.all()
+    serializer_class = TodoYetAnotherSerializer
+
+
+class NestedTodoView(RetrieveAPIView):
     serializer_class = TodoYetAnotherSerializer

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -546,6 +546,27 @@ paths:
         description: A unique integer value identifying this todo.
         required: true
         type: integer
+  /todo/{todo_id}/yetanother/{yetanother_id}/:
+    get:
+      operationId: todo_yetanother_read
+      description: ''
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/TodoYetAnother'
+      tags:
+        - todo
+    parameters:
+      - name: todo_id
+        in: path
+        required: true
+        type: string
+      - name: yetanother_id
+        in: path
+        required: true
+        type: string
   /users/:
     get:
       operationId: users_list


### PR DESCRIPTION
Resolves #105 

Without the sorted() then the `parameters` ordering here is random depending on `PYTHONHASHSEED`, so test will fail ~50% of time:

```
    parameters:
      - name: todo_id
        in: path
        required: true
        type: string
      - name: yetanother_id
        in: path
        required: true
        type: string

```
https://github.com/axnsan12/drf-yasg/compare/master...therefromhere:stable_parameters_order?expand=1#diff-a9b50452eecdae91c8e1e478e092b2e4R561

It would be nice if we could show parameters in the same ordering as the URL, but unfortunately `uritemplate` doesn't provide that.