### PR TITLE
FileFieldInspector should not set read_only=True by default.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -36,7 +36,7 @@ You want to contribute some code? Great! Here are a few steps to get you started
       $ virtualenv venv
       $ source venv/bin/activate
       (venv) $ pip install -e .[validation]
-      (venv) $ pip install -rrequirements/dev.txt "Django>=1.11.7"
+      (venv) $ pip install -r requirements/dev.txt "Django>=1.11.7"
 
 #. **Make your changes and check them against the test project**
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -36,7 +36,7 @@ You want to contribute some code? Great! Here are a few steps to get you started
       $ virtualenv venv
       $ source venv/bin/activate
       (venv) $ pip install -e .[validation]
-      (venv) $ pip install -r requirements/dev.txt "Django>=1.11.7"
+      (venv) $ pip install -rrequirements/dev.txt "Django>=1.11.7"
 
 #. **Make your changes and check them against the test project**
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -36,7 +36,7 @@ You want to contribute some code? Great! Here are a few steps to get you started
       $ virtualenv venv
       $ source venv/bin/activate
       (venv) $ pip install -e .[validation]
-      (venv) $ pip install -rrequirements/dev.txt "Django>=1.11.7"
+      (venv) $ pip install -r requirements/dev.txt
 
 #. **Make your changes and check them against the test project**
 

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -433,8 +433,7 @@ class FileFieldInspector(FieldInspector):
             err = SwaggerGenerationError("FileField is supported only in a formData Parameter or response Schema")
             if swagger_object_type == openapi.Schema:
                 # FileField.to_representation returns URL or file name
-                result = SwaggerType(type=openapi.TYPE_STRING,
-                                     read_only=field.read_only)
+                result = SwaggerType(type=openapi.TYPE_STRING, read_only=True)
                 if getattr(field, 'use_url', rest_framework_settings.UPLOADED_FILES_USE_URL):
                     result.format = openapi.FORMAT_URI
                 return result

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -67,10 +67,12 @@ class InlineSerializerInspector(SerializerInspector):
                     }
                     prop_kwargs = filter_none(prop_kwargs)
 
-                    properties[property_name] = self.probe_field_inspectors(
+                    child_schema = self.probe_field_inspectors(
                         child, ChildSwaggerType, use_references, **prop_kwargs
                     )
-                    if child.required:
+                    properties[property_name] = child_schema
+
+                    if child.required and not getattr(child_schema, 'read_only', False):
                         required.append(property_name)
 
                 result = SwaggerType(

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -433,7 +433,8 @@ class FileFieldInspector(FieldInspector):
             err = SwaggerGenerationError("FileField is supported only in a formData Parameter or response Schema")
             if swagger_object_type == openapi.Schema:
                 # FileField.to_representation returns URL or file name
-                result = SwaggerType(type=openapi.TYPE_STRING, read_only=True)
+                result = SwaggerType(type=openapi.TYPE_STRING,
+                                     read_only=field.read_only)
                 if getattr(field, 'use_url', rest_framework_settings.UPLOADED_FILES_USE_URL):
                     result.format = openapi.FORMAT_URI
                 return result

--- a/testproj/articles/serializers.py
+++ b/testproj/articles/serializers.py
@@ -11,7 +11,7 @@ class ArticleSerializer(serializers.ModelSerializer):
         read_only=True,
     )
     uuid = serializers.UUIDField(help_text="should articles have UUIDs?", read_only=True)
-    cover_name = serializers.FileField(use_url=False, source='cover', read_only=True)
+    cover_name = serializers.FileField(use_url=False, source='cover', required=True)
     group = serializers.SlugRelatedField(slug_field='uuid', queryset=ArticleGroup.objects.all())
     original_group = serializers.SlugRelatedField(slug_field='uuid', read_only=True)
 

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -870,7 +870,7 @@ definitions:
         readOnly: true
       cover:
         type: string
-        readOnly: true
+        readOnly: false
         format: uri
       cover_name:
         type: string

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -870,7 +870,7 @@ definitions:
         readOnly: true
       cover:
         type: string
-        readOnly: false
+        readOnly: true
         format: uri
       cover_name:
         type: string


### PR DESCRIPTION
The schema generated from a FileField with required=True set will
generate the following error when validated:
`Read only properties cannot be marked as required by a schema.`