### PR TITLE
swagger_extra_fields should be allowed even when we don't call get_schema

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,18 @@ Changelog
 
 
 *********
+**1.9.0**
+*********
+
+*Release date: Jun 16, 2018*
+
+- **ADDED:** added ``DEFAULT_GENERATOR_CLASS`` setting and ``--generator-clas`` argument to the ``generate_swagger``
+  management command (:issue:`140`)
+- **FIXED:** fixed wrongly required ``'count'`` response field on ``CursorPagination`` (:issue:`141`)
+- **FIXED:** fixed crash when encountering ``coreapi.Fields``\ s without a ``schema`` (:issue:`143`)
+
+
+*********
 **1.8.0**
 *********
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -43,6 +43,14 @@ The possible settings and their default values are as follows:
 Default classes
 ===============
 
+DEFAULT_GENERATOR_CLASS
+-------------------------
+
+:class:`~.generators.OpenAPISchemaGenerator` subclass that will be used by default for generating the final
+:class:`.Schema` object. Can be overriden by the ``generator_class`` argument to :func:`.get_schema_view`.
+
+**Default**: :class:`drf_yasg.generators.OpenAPISchemaGenerator`
+
 DEFAULT_AUTO_SCHEMA_CLASS
 -------------------------
 
@@ -102,7 +110,7 @@ DEFAULT_INFO
 ------------
 
 An import string to an :class:`.openapi.Info` object. This will be used when running the ``generate_swagger``
-management command, or if no ``info`` argument is passed to ``get_schema_view``.
+management command, or if no ``info`` argument is passed to :func:`.get_schema_view`.
 
 **Default**: :python:`None`
 

--- a/src/drf_yasg/app_settings.py
+++ b/src/drf_yasg/app_settings.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from rest_framework.settings import perform_import
 
 SWAGGER_DEFAULTS = {
+    'DEFAULT_GENERATOR_CLASS': 'drf_yasg.generators.OpenAPISchemaGenerator',
     'DEFAULT_AUTO_SCHEMA_CLASS': 'drf_yasg.inspectors.SwaggerAutoSchema',
 
     'DEFAULT_FIELD_INSPECTORS': [
@@ -68,6 +69,7 @@ REDOC_DEFAULTS = {
 }
 
 IMPORT_STRINGS = [
+    'DEFAULT_GENERATOR_CLASS',
     'DEFAULT_AUTO_SCHEMA_CLASS',
     'DEFAULT_FIELD_INSPECTORS',
     'DEFAULT_FILTER_INSPECTORS',

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -117,6 +117,10 @@ class InlineSerializerInspector(SerializerInspector):
                     # but is visually displayed like the model name, which is confusing
                     # it is better to just remove title from inline models
                     del result.title
+
+                # Provide an option to add manual paremeters to a schema
+                # for example, to add examples
+                self.add_manual_fields(field, result)
                 return result
 
             if not ref_name or not use_references:

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -36,10 +36,7 @@ class InlineSerializerInspector(SerializerInspector):
                 setattr(schema, attr, val)
 
     def get_schema(self, serializer):
-        result = self.probe_field_inspectors(serializer, openapi.Schema, self.use_definitions)
-        schema = openapi.resolve_ref(result, self.components)
-        self.add_manual_fields(serializer, schema)
-        return result
+        return self.probe_field_inspectors(serializer, openapi.Schema, self.use_definitions)
 
     def add_manual_parameters(self, serializer, parameters):
         """Add/replace parameters from the given list of automatically generated request parameters. This method

--- a/src/drf_yasg/inspectors/query.py
+++ b/src/drf_yasg/inspectors/query.py
@@ -48,7 +48,7 @@ class CoreAPICompatInspector(PaginatorInspector, FilterInspector):
             in_=location_to_in[field.location],
             type=coreapi_types.get(type(field.schema), openapi.TYPE_STRING),
             required=field.required,
-            description=field.schema.description,
+            description=field.schema.description if field.schema else None,
         )
 
 

--- a/src/drf_yasg/inspectors/query.py
+++ b/src/drf_yasg/inspectors/query.py
@@ -70,7 +70,10 @@ class DjangoRestResponsePagination(PaginatorInspector):
                     ('previous', openapi.Schema(type=openapi.TYPE_STRING, format=openapi.FORMAT_URI)),
                     ('results', response_schema),
                 )),
-                required=['count', 'results']
+                required=['results']
             )
+
+            if has_count:
+                paged_schema.required.insert(0, 'count')
 
         return paged_schema

--- a/src/drf_yasg/views.py
+++ b/src/drf_yasg/views.py
@@ -11,7 +11,6 @@ from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from .app_settings import swagger_settings
-from .generators import OpenAPISchemaGenerator
 from .renderers import OpenAPIRenderer, ReDocRenderer, SwaggerJSONRenderer, SwaggerUIRenderer, SwaggerYAMLRenderer
 
 SPEC_RENDERERS = (SwaggerYAMLRenderer, SwaggerJSONRenderer, OpenAPIRenderer)
@@ -46,7 +45,7 @@ def deferred_never_cache(view_func):
 
 
 def get_schema_view(info=None, url=None, patterns=None, urlconf=None, public=False, validators=None,
-                    generator_class=OpenAPISchemaGenerator,
+                    generator_class=swagger_settings.DEFAULT_GENERATOR_CLASS,
                     authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
                     permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
     """Create a SchemaView class with default renderers and generators.

--- a/testproj/todo/urls.py
+++ b/testproj/todo/urls.py
@@ -13,6 +13,6 @@ router.register(r'recursive', views.TodoRecursiveView)
 urlpatterns = router.urls
 
 urlpatterns += [
-    url(r'^(?P<todo_id>\d+)/yetanother/(?P<yetanother_id>\d+)/$',
+    url(r'^(?P<todo_id>\d+)/yetanothers/(?P<yetanother_id>\d+)/$',
         views.NestedTodoView.as_view(), ),
 ]

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -697,9 +697,9 @@ paths:
         description: A unique integer value identifying this todo.
         required: true
         type: integer
-  /todo/{todo_id}/yetanother/{yetanother_id}/:
+  /todo/{todo_id}/yetanothers/{yetanother_id}/:
     get:
-      operationId: todo_yetanother_read
+      operationId: todo_yetanothers_read
       description: ''
       parameters: []
       responses:


### PR DESCRIPTION
It appears that it is possible to write a Schema Definition for use with a SchemaRef without creating the object through `get_schema`. The side effect of this is that if you have specified `schema_extra_fields` with parameters you care about (such as examples) they never get set.

This patch adds support for custom fields even when building a SchemaRef because it is possible for `field_to_swagger_object` to get called without calling `get_schema`. The below example illustrates a case where this happens.

Example:
```
class TestObj(object):
    foobar = None
    barfoo = None

    def __init__(self, **kwargs):
        setattr(self, 'foobar', kwargs.get('foobar'))
        setattr(self, 'barfoo', kwargs.get('barfoo'))


class TestSerializer(serializers.Serializer):
    barfoo = serializers.CharField(max_length=50)
    foobar = serializers.CharField(max_length=300)

    def create(self, data):
        return TestObj(**data)

    class Meta:
        swagger_schema_fields = {
            'example': {
                'barfoo': '1234',
                'foobar': '456'
            }
        }


class TestView(viewsets.ViewSet):
    """
    Test example view
    """

    permission_classes = [permissions.IsAuthenticated]
    lookup_field = 'address_partial'

    @swagger_auto_schema(
        operation_id='testview_get',
        description='#TestSerializer Example',
        responses={
            '200': TestSerializer(many=True)
        },
        permission_classes=[permissions.IsAuthenticated])
    def retrieve(self, request, pk=None, address_partial=None):
        response = {
            'hits': [
                {
                  'barfoo': 'asdf',
                  'foobar': 'foobar'
                }
            ]
        }
        serializer = TestSerializer(
            instance=response['hits'],
            many=True)
        return Response(serializer.data, status=status.HTTP_200_OK)
```

Without the patch, this will omit the `example` additional field. With the patch, it won't.