### PR TITLE
Handle duplicate urls in urlconf

### DIFF
--- a/tests/test_schema_generator.py
+++ b/tests/test_schema_generator.py
@@ -2,10 +2,10 @@ import json
 from collections import OrderedDict
 
 import pytest
-from django.urls import path
+from django.conf.urls import url
 from rest_framework import routers, serializers, viewsets
-from rest_framework.response import Response
 from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
 from drf_yasg import codecs, openapi
 from drf_yasg.codecs import yaml_sane_load
@@ -130,8 +130,8 @@ def test_url_order():
         return Response({"message": "Hello, world!"})
 
     patterns = [
-        path('/test/', test_override),
-        path('/test/', test_view),
+        url(r'^/test/$', test_override),
+        url(r'^/test/$', test_view),
     ]
 
     generator = OpenAPISchemaGenerator(


### PR DESCRIPTION
Django resolves urls in order from top to bottom, and only uses the first matching URL found. This can happen for example when overriding one view in an existing app:

```
    path('accounts/login/', user_views.LoginView.as_view(), name='login'),
    path('accounts/', include('django.contrib.auth.urls')),  # logout, password change, password reset
```

drf-yasg doesn't follow Django's behavior, and instead uses the last view for a given path+method. This means duplicate URLs are documented incorrectly in the resulting schema.

This PR adds a test to show the correct behavior, and a filter to `OpenAPISchemaGenerator.get_api_endpoints` to ensure that each path is only included once.