### PR TITLE
make generate_swagger work for projects without authentication

### DIFF
--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -17,7 +17,7 @@ from drf_yasg.generators import OpenAPISchemaGenerator
 
 
 def call_generate_swagger(output_file='-', overwrite=False, format='', api_url='',
-                          mock=False, user='', private=False, generator_class_name='', **kwargs):
+                          mock=False, user=None, private=False, generator_class_name='', **kwargs):
     out = StringIO()
     call_command(
         'generate_swagger', stdout=out,


### PR DESCRIPTION
Hello,

I needed to generate the schema with `./manager.py generate_swagger` for a project on which there isn't any Django authentication configured.

The issue was that the `User` import in `generate_swagger.py` failed in this environment, so the schema wasn't generated.

I fixed it so that the schema can still generated. Passing the `--user` option also raises an error if auth is unconfigured. It passes the tests and the linter.

Could you consider merging ? That would be a very nice feature to have in the official repo for me (at least).

Thank you !