### PR TITLE
Fix a link in the docs

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -313,7 +313,7 @@ ReDoc UI settings
 =================
 
 ReDoc UI configuration settings. |br|
-See https://github.com/Rebilly/ReDoc#redoc-tag-attributes.
+See https://github.com/Rebilly/ReDoc/tree/v1.x#redoc-tag-attributes.
 
 LAZY_RENDERING
 --------------


### PR DESCRIPTION
ReDoc now is in v2 (whatever that entails), which doesn't include the
target of the original link. I've made the link point explicitly to the
v1 readme, which includes the original target.