### PR TITLE
Add missing `operation_summary` and `deprecated` to `swagger_auto_schema`

### DIFF
--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -107,6 +107,8 @@ def swagger_auto_schema(method=None, methods=None, auto_schema=unset, request_bo
             'query_serializer': query_serializer,
             'manual_parameters': manual_parameters,
             'operation_id': operation_id,
+            'operation_summary': operation_summary,
+            'deprecated': deprecated,
             'operation_description': operation_description,
             'security': security,
             'responses': responses,

--- a/testproj/articles/views.py
+++ b/testproj/articles/views.py
@@ -137,7 +137,8 @@ class ArticleViewSet(viewsets.ModelViewSet):
         """update method docstring"""
         return super(ArticleViewSet, self).update(request, *args, **kwargs)
 
-    @swagger_auto_schema(operation_description="partial_update description override", responses={404: 'slug not found'})
+    @swagger_auto_schema(operation_description="partial_update description override", responses={404: 'slug not found'},
+                         operation_summary='partial_update summary', deprecated=True)
     def partial_update(self, request, *args, **kwargs):
         """partial_update method docstring"""
         return super(ArticleViewSet, self).partial_update(request, *args, **kwargs)

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -151,6 +151,7 @@ paths:
         - articles
     patch:
       operationId: articles_partial_update
+      summary: partial_update summary
       description: partial_update description override
       parameters:
         - name: data
@@ -167,6 +168,7 @@ paths:
           description: slug not found
       tags:
         - articles
+      deprecated: true
     delete:
       operationId: articles_delete
       description: destroy method docstring


### PR DESCRIPTION
The previous PR missed adding these to extra overrides.

- Added tests
- Updated reference.yaml

Refs #149, #173.