### PR TITLE
Allow description of parameters of ViewSets not using Models

### DIFF
--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -436,6 +436,12 @@ class OpenAPISchemaGenerator(object):
                 description = model_field.help_text
             elif model_field and getattr(model_field, 'primary_key', False):
                 description = get_pk_description(model, model_field)
+            elif 'param:' in view_cls.__doc__:
+                description = None
+                for line in view_cls.__doc__.splitlines():
+                    param_variable = 'param: ' + variable + ': '
+                    if line.strip().startswith(param_variable):
+                        description = line[line.find(param_variable) + len(param_variable):]
             else:
                 description = None
 

--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -436,7 +436,7 @@ class OpenAPISchemaGenerator(object):
                 description = model_field.help_text
             elif model_field and getattr(model_field, 'primary_key', False):
                 description = get_pk_description(model, model_field)
-            elif 'param:' in view_cls.__doc__:
+            elif view_cls.__doc__ is not None and 'param:' in view_cls.__doc__:
                 description = None
                 for line in view_cls.__doc__.splitlines():
                     param_variable = 'param: ' + variable + ': '


### PR DESCRIPTION
Allow parameters of ViewSets not using Models to describe their parameters in their docstring.