### PR TITLE
fixed missing backslashes found via pytest 3.8

### DIFF
--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -134,7 +134,7 @@ class EndpointEnumerator(_EndpointEnumerator):
         """Remove backslashe escapes from all path components outside {parameters}. This is needed because
         ``simplify_regex`` does not handle this correctly - note however that this implementation is
 
-        **NOTE:** this might destructively affect some url regex patterns that contain metacharacters (e.g. \w, \d)
+        **NOTE:** this might destructively affect some url regex patterns that contain metacharacters (e.g. \\w, \\d)
         outside path parameter groups; if you are in this category, God help you
 
         :param str path: path possibly containing

--- a/src/drf_yasg/inspectors/base.py
+++ b/src/drf_yasg/inspectors/base.py
@@ -258,7 +258,7 @@ class SerializerInspector(FieldInspector):
         return NotHandled
 
     def get_request_parameters(self, serializer, in_):
-        """Convert a DRF serializer into a list of :class:`.Parameter`\ s.
+        """Convert a DRF serializer into a list of :class:`.Parameter`\\ s.
 
         Should return :data:`.NotHandled` if this inspector does not know how to handle the given `serializer`.
 
@@ -372,7 +372,7 @@ class ViewInspector(BaseInspector):
         )
 
     def serializer_to_parameters(self, serializer, in_):
-        """Convert a serializer to a possibly empty list of :class:`.Parameter`\ s.
+        """Convert a serializer to a possibly empty list of :class:`.Parameter`\\ s.
 
         :param serializers.BaseSerializer serializer: the ``Serializer`` instance
         :param str in_: the location of the parameters, one of the `openapi.IN_*` constants

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -196,7 +196,7 @@ def get_related_model(model, source):
 
 
 class RelatedFieldInspector(FieldInspector):
-    """Provides conversions for ``RelatedField``\ s."""
+    """Provides conversions for ``RelatedField``\\ s."""
 
     def field_to_swagger_object(self, field, swagger_object_type, use_references, **kwargs):
         SwaggerType, ChildSwaggerType = self._get_partial_types(field, swagger_object_type, use_references, **kwargs)
@@ -570,7 +570,7 @@ class ChoiceFieldInspector(FieldInspector):
 
 
 class FileFieldInspector(FieldInspector):
-    """Provides conversions for ``FileField``\ s."""
+    """Provides conversions for ``FileField``\\ s."""
 
     def field_to_swagger_object(self, field, swagger_object_type, use_references, **kwargs):
         SwaggerType, ChildSwaggerType = self._get_partial_types(field, swagger_object_type, use_references, **kwargs)

--- a/src/drf_yasg/inspectors/query.py
+++ b/src/drf_yasg/inspectors/query.py
@@ -9,7 +9,7 @@ from .base import FilterInspector, PaginatorInspector
 
 
 class CoreAPICompatInspector(PaginatorInspector, FilterInspector):
-    """Converts ``coreapi.Field``\ s to :class:`.openapi.Parameter`\ s for filters and paginators that implement a
+    """Converts ``coreapi.Field``\\ s to :class:`.openapi.Parameter`\\ s for filters and paginators that implement a
     ``get_schema_fields`` method.
     """
 

--- a/src/drf_yasg/inspectors/view.py
+++ b/src/drf_yasg/inspectors/view.py
@@ -63,7 +63,7 @@ class SwaggerAutoSchema(ViewInspector):
         -  a list of primitive Parameters parsed as form data
 
         :param list[str] consumes: a list of accepted MIME types as returned by :meth:`.get_consumes`
-        :return: a (potentially empty) list of :class:`.Parameter`\ s either ``in: body`` or ``in: formData``
+        :return: a (potentially empty) list of :class:`.Parameter`\\ s either ``in: body`` or ``in: formData``
         :rtype: list[openapi.Parameter]
         """
         serializer = self.get_request_serializer()
@@ -129,7 +129,7 @@ class SwaggerAutoSchema(ViewInspector):
         return body_override
 
     def get_request_form_parameters(self, serializer):
-        """Given a Serializer, return a list of ``in: formData`` :class:`.Parameter`\ s.
+        """Given a Serializer, return a list of ``in: formData`` :class:`.Parameter`\\ s.
 
         :param serializer: the view's request serializer as returned by :meth:`.get_request_serializer`
         :rtype: list[openapi.Parameter]
@@ -223,7 +223,7 @@ class SwaggerAutoSchema(ViewInspector):
     def get_response_serializers(self):
         """Return the response codes that this view is expected to return, and the serializer for each response body.
         The return value should be a dict where the keys are possible status codes, and values are either strings,
-        ``Serializer``\ s, :class:`.Schema`, :class:`.SchemaRef` or :class:`.Response` objects. See
+        ``Serializer``\\ s, :class:`.Schema`, :class:`.SchemaRef` or :class:`.Response` objects. See
         :func:`@swagger_auto_schema <.swagger_auto_schema>` for more details.
 
         :return: the response serializers

--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -434,9 +434,9 @@ class Schema(SwaggerDict):
         :param bool,.Schema,.SchemaRef additional_properties: allow wildcard properties not listed in `properties`
         :param list[str] required: list of requried property names
         :param .Schema,.SchemaRef items: type of array items, only valid if `type` is ``array``
-        :param default: only valid when insider another ``Schema``\ 's ``properties``;
+        :param default: only valid when insider another ``Schema``\\ 's ``properties``;
             the default value of this property if it is not provided, must conform to the type of this Schema
-        :param read_only: only valid when insider another ``Schema``\ 's ``properties``;
+        :param read_only: only valid when insider another ``Schema``\\ 's ``properties``;
             declares the property as read only - it must only be sent as part of responses, never in requests
         """
         super(Schema, self).__init__(**extra)

--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -50,7 +50,7 @@ def swagger_auto_schema(method=None, methods=None, auto_schema=unset, request_bo
         the `manual_parameters` argument.
 
         If a ``Serializer`` class or instance is given, it will be automatically converted into a :class:`.Schema`
-        used as a ``body`` :class:`.Parameter`, or into a list of ``form`` :class:`.Parameter`\ s, as appropriate.
+        used as a ``body`` :class:`.Parameter`, or into a list of ``form`` :class:`.Parameter`\\ s, as appropriate.
 
     :param .Serializer query_serializer: if you use a ``Serializer`` to parse query parameters, you can pass it here
         and have :class:`.Parameter` objects be generated automatically from it.
@@ -63,7 +63,7 @@ def swagger_auto_schema(method=None, methods=None, auto_schema=unset, request_bo
 
     :param list[.Parameter] manual_parameters: a list of manual parameters to override the automatically generated ones
 
-        :class:`.Parameter`\ s are identified by their (``name``, ``in``) combination, and any parameters given
+        :class:`.Parameter`\\ s are identified by their (``name``, ``in``) combination, and any parameters given
         here will fully override automatically generated parameters if they collide.
 
         It is an error to supply ``form`` parameters when the request does not consume form-data.


### PR DESCRIPTION
See: https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals

Changed in version 3.6: Unrecognized escape sequences produce a DeprecationWarning