### PR TITLE
Set x-nullable based on field informations

### DIFF
--- a/src/drf_yasg/inspectors/base.py
+++ b/src/drf_yasg/inspectors/base.py
@@ -192,7 +192,7 @@ class FieldInspector(BaseInspector):
 
             - arguments specified by the ``kwargs`` parameter of :meth:`._get_partial_types`
             - ``instance_kwargs`` passed to the constructor function
-            - ``title``, ``description``, ``required`` and ``default`` inferred from the field,
+            - ``title``, ``description``, ``required``, ``x-nullable`` and ``default`` inferred from the field,
               where appropriate
 
           If ``existing_object`` is not ``None``, it is updated instead of creating a new object.
@@ -225,6 +225,9 @@ class FieldInspector(BaseInspector):
                 instance_kwargs.setdefault('title', title)
             if description is not None:
                 instance_kwargs.setdefault('description', description)
+            if field.allow_null:
+                instance_kwargs['x_nullable'] = True
+
             instance_kwargs.update(kwargs)
 
             if existing_object is not None:

--- a/testproj/articles/serializers.py
+++ b/testproj/articles/serializers.py
@@ -33,7 +33,12 @@ class ArticleSerializer(serializers.ModelSerializer):
 
 
 class ImageUploadSerializer(serializers.Serializer):
-    what_am_i_doing = serializers.RegexField(regex=r"^69$", help_text="test", default="69")
+    what_am_i_doing = serializers.RegexField(
+        regex=r"^69$",
+        help_text="test",
+        default="69",
+        allow_null=True
+    )
     image_styles = serializers.ListSerializer(
         child=serializers.ChoiceField(choices=['wide', 'tall', 'thumb', 'social']),
         help_text="Parameter with Items"

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -207,6 +207,7 @@ paths:
           pattern: ^69$
           default: '69'
           minLength: 1
+          x-nullable: true
         - name: image_styles
           in: formData
           description: Parameter with Items
@@ -885,6 +886,7 @@ definitions:
           - 3
           - 7
           - 8
+        x-nullable: true
       group:
         type: string
         format: uuid
@@ -903,6 +905,7 @@ definitions:
         pattern: ^69$
         default: '69'
         minLength: 1
+        x-nullable: true
       image_styles:
         description: Parameter with Items
         type: array
@@ -931,12 +934,14 @@ definitions:
         type: string
         maxLength: 30
         minLength: 1
+        x-nullable: true
       last_name:
         title: Last name
         description: <strong>Here's some HTML!</strong>
         type: string
         maxLength: 30
         minLength: 1
+        x-nullable: true
   Person:
     required:
       - identity
@@ -1488,6 +1493,7 @@ definitions:
         type: array
         items:
           type: integer
+        x-nullable: true
       exampleProjects:
         type: array
         items:
@@ -1552,6 +1558,7 @@ definitions:
       parent_id:
         type: integer
         title: Parent id
+        x-nullable: true
   TodoTree:
     required:
       - title


### PR DESCRIPTION
Many fields may be set a nullable in an API. While not covered explicitly
by Swagger 2, this information is usually indicated as a
[vendor extension](https://swagger.io/docs/specification/2-0/swagger-extensions/)
using the x-nullable field.