### PR TITLE
Adding Exception language to let the developer know where the problem is

### DIFF
--- a/src/drf_yasg/inspectors/base.py
+++ b/src/drf_yasg/inspectors/base.py
@@ -335,8 +335,11 @@ class ViewInspector(BaseInspector):
             return []
 
         fields = []
-        for filter_backend in self.view.filter_backends:
-            fields += self.probe_inspectors(self.filter_inspectors, 'get_filter_parameters', filter_backend()) or []
+        try:
+            for filter_backend in self.view.filter_backends:
+                fields += self.probe_inspectors(self.filter_inspectors, 'get_filter_parameters', filter_backend()) or []
+        except Exception as identifier:
+            raise Exception("Error Iterating filter_backends of view {}".format(str(self.view)))
 
         return fields
 


### PR DESCRIPTION
Adding a text to let the user know he forgot to add the filter_backends as an iterable object.
This way it's easier to know in what view the user forgot to do so