### PR TITLE
pycharm manage.py compatibility fix

### DIFF
--- a/src/drf_yasg/management/commands/generate_swagger.py
+++ b/src/drf_yasg/management/commands/generate_swagger.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '-f', '--format', dest='format',
-            default='', choices=('json', 'yaml'),
+            default='', choices=['json', 'yaml'],
             type=str,
             help='Output format. If not given, it is guessed from the output file extension and defaults to json.'
         )


### PR DESCRIPTION
Hello sir, your awesome module is causing a tiny error in the IDE im using, other users could also experience this error. The fix is very simple.

in pycharm 2016.3, I am not sure about newer versions, because this is the only version that I own.
pycharm django manage commands autocomple fails loading with error:

Traceback (most recent call last):
  File "/home/*****/pycharm-2016.3.6/helpers/pycharm/_jb_manage_tasks_provider.py", line 28, in <module>
    parser.report_data(dumper, commands_to_skip)
  File "/home/*****/pycharm-2016.3.6/helpers/pycharm/django_manage_commands_provider/_parser/parser.py", line 90, in report_data
    module_to_use.process_command(dumper, command, parser)
  File "/home/*****/pycharm-2016.3.6/helpers/pycharm/django_manage_commands_provider/_parser/_argparse.py", line 43, in process_command
    argument_info = (1, _utils.get_opt_type(action))
  File "/home/*****/pycharm-2016.3.6/helpers/pycharm/django_manage_commands_provider/_parser/_utils.py", line 20, in get_opt_type
    assert isinstance(opt.choices, list), "Choices should be list"
AssertionError: Choices should be list

I don't know if there is a convention for this, but this is the first time I encounter this error in PyCharm.