### PR TITLE
Add pyproject.toml (implement PEP518)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,12 @@ jobs:
       python: '3.7'
       dist: xenial
       sudo: required
-    -
-      python: '3.6'
+    - python: '3.6'
       env: TOXENV=djmaster
     - # readthedocs uses python 3.5 for building
       python: '3.5'
       env: TOXENV=docs
-    -
-      python: '3.6'
+    - python: '3.6'
       env: TOXENV=lint
 
     - stage: publish
@@ -45,13 +43,14 @@ jobs:
   fast_finish: true
 
 install:
- - pip install -r requirements/ci.txt
+  - python -m pip install -U pip
+  - pip install -r requirements/ci.txt
 
 before_script:
- - coverage erase
+  - coverage erase
 
 script:
- - tox
+  - tox
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
   fast_finish: true
 
 install:
-  - python -m pip install -U pip
+  - python -m pip install -U pip setuptools
   - pip install -r requirements/ci.txt
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ jobs:
 
     - stage: publish
       python: '3.6'
+      before_script:
+        # workaround for Travis' inability to build PEP517 projects; anything added to build-system.requires
+        # will also have to be added here until Travis implements this
+        - pip install setuptools-scm
       script: skip
       env: PYPI_DEPLOY=true
       deploy: &pypi

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -35,7 +35,7 @@ You want to contribute some code? Great! Here are a few steps to get you started
 
       $ virtualenv venv
       $ source venv/bin/activate
-      (venv) $ python -m pip install -U pip
+      (venv) $ python -m pip install -U pip setuptools
       (venv) $ pip install -U -e .[validation]
       (venv) $ pip install -U -r requirements/dev.txt
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -35,6 +35,7 @@ You want to contribute some code? Great! Here are a few steps to get you started
 
       $ virtualenv venv
       $ source venv/bin/activate
+      (venv) $ python -m pip install -U pip
       (venv) $ pip install -U -e .[validation]
       (venv) $ pip install -U -r requirements/dev.txt
 
@@ -57,8 +58,7 @@ You want to contribute some code? Great! Here are a few steps to get you started
 
    .. code:: console
 
-      (venv) $ cd testproj
-      (venv) $ python manage.py generate_swagger ../tests/reference.yaml --overwrite --user admin --url http://test.local:8002/
+      (venv) $ python testproj/manage.py generate_swagger ../tests/reference.yaml --overwrite --user admin --url http://test.local:8002/
 
    After checking the git diff to verify that no unexpected changes appeared, you should commit the new
    ``reference.yaml`` together with your changes.
@@ -67,13 +67,13 @@ You want to contribute some code? Great! Here are a few steps to get you started
 
    .. code:: console
 
-      # (optional) sort imports with isort and check flake8 linting
-      (venv) $ isort --apply
-      (venv) $ flake8 src/drf_yasg testproj tests setup.py
       # install test dependencies
       (venv) $ pip install -U -r requirements/test.txt
       # run tests in the current environment, faster than tox
       (venv) $ pytest -n auto --cov
+      # (optional) sort imports with isort and check flake8 linting
+      (venv) $ isort --apply
+      (venv) $ flake8 src/drf_yasg testproj tests setup.py
       # (optional) run tests for other python versions in separate environments
       (venv) $ tox
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
 include LICENSE.rst
+include pyproject.toml
 recursive-include requirements *
 recursive-include src/drf_yasg/static *
 recursive-include src/drf_yasg/templates *

--- a/README.rst
+++ b/README.rst
@@ -294,7 +294,7 @@ For additional usage examples, you can take a look at the test project in the ``
    $ virtualenv venv
    $ source venv/bin/activate
    (venv) $ cd testproj
-   (venv) $ python -m pip install -U pip
+   (venv) $ python -m pip install -U pip setuptools
    (venv) $ pip install -U -r requirements.txt
    (venv) $ python manage.py migrate
    (venv) $ python manage.py shell -c "import createsuperuser"

--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,7 @@ In ``urls.py``:
       ...
    ]
 
-This exposes 4 cached, validated and publicly available endpoints:
+This exposes 4 endpoints:
 
 * A JSON view of your API specification at ``/swagger.json``
 * A YAML view of your API specification at ``/swagger.yaml``
@@ -294,6 +294,7 @@ For additional usage examples, you can take a look at the test project in the ``
    $ virtualenv venv
    $ source venv/bin/activate
    (venv) $ cd testproj
+   (venv) $ python -m pip install -U pip
    (venv) $ pip install -U -r requirements.txt
    (venv) $ python manage.py migrate
    (venv) $ python manage.py shell -c "import createsuperuser"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "setuptools-scm"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["setuptools", "wheel", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
--r requirements/setup.txt
+# this file is only used when deploying to heroku, because heroku insists on having a root-level requirements.txt
+# for normal usage see the requirements/ directory
 .[validation]
 -r requirements/heroku.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,7 +2,8 @@
 Sphinx>=1.7.0
 sphinx_rtd_theme>=0.2.4
 Pillow>=4.3.0
-readme_renderer>=17.2
+readme_renderer[md]>=24.0
+twine>=1.12.1
 
 Django>=2.0
 djangorestframework_camel_case>=0.2.0

--- a/requirements/setup.txt
+++ b/requirements/setup.txt
@@ -1,3 +1,0 @@
-# needed to build the package setup_requires in setup.py
-
-setuptools-scm>=3.0.6

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -1,2 +1,2 @@
 # requirements for building and running tox
-tox>=3.1.2
+tox>=3.3.0

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -1,4 +1,2 @@
 # requirements for building and running tox
 tox>=3.1.2
-
--r setup.txt

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.7
+python-3.7.1

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ with io.open('README.rst', encoding='utf-8') as readme:
     description = readme.read()
 
 requirements = read_req('base.txt')
-requirements_setup = read_req('setup.txt')
 requirements_validation = read_req('validation.txt')
 
 
@@ -28,7 +27,6 @@ def drf_yasg_setup(**kwargs):
         package_dir={'': 'src'},
         include_package_data=True,
         install_requires=requirements,
-        setup_requires=requirements_setup,
         extras_require={
             'validation': requirements_validation,
         },

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ deps =
     djmaster: https://github.com/django/django/archive/master.tar.gz
 
     # other dependencies
-    -rrequirements/setup.txt
     -rrequirements/validation.txt
     -rrequirements/test.txt
 
@@ -37,7 +36,6 @@ commands =
 
 [testenv:docs]
 deps =
-    -rrequirements/setup.txt
     -rrequirements/docs.txt
 commands =
     python setup.py check --restructuredtext --metadata --strict

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ commands =
 deps =
     -r requirements/docs.txt
 commands =
-    python setup.py check --restructuredtext --metadata --strict
+    twine check .tox/dist/*
     sphinx-build -WnEa -b html docs docs/_build/html
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,17 @@
 [tox]
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
+minversion = 3.3.0
+isolated_build = true
+isolated_build_env=.package
 envlist =
     py{27,34,35,36}-django111-drf{37,38,39},
     py{34,35,36,37}-django20-drf{37,38,39},
     py{35,36,37}-django21-drf{37,38,39},
     djmaster, lint, docs
+
+[testenv:.package]
+# no additional dependencies besides PEP 517
+deps =
 
 [testenv]
 deps =
@@ -21,8 +28,8 @@ deps =
     djmaster: https://github.com/django/django/archive/master.tar.gz
 
     # other dependencies
-    -rrequirements/validation.txt
-    -rrequirements/test.txt
+    -r requirements/validation.txt
+    -r requirements/test.txt
 
 commands =
     pytest -n 2 --cov --cov-config .coveragerc --cov-append --cov-report="" {posargs}
@@ -30,13 +37,13 @@ commands =
 [testenv:lint]
 skip_install = true
 deps =
-    -rrequirements/lint.txt
+    -r requirements/lint.txt
 commands =
     flake8 src/drf_yasg testproj tests setup.py
 
 [testenv:docs]
 deps =
-    -rrequirements/docs.txt
+    -r requirements/docs.txt
 commands =
     python setup.py check --restructuredtext --metadata --strict
     sphinx-build -WnEa -b html docs docs/_build/html


### PR DESCRIPTION
- [x] add `pyproject.toml` with `build-system.requires`
- [x] remove `setup_requires` from `setup.py`
- [x] remove `requirements/setup.txt`
- [x] add `pip install -U pip setuptools` where appropriate
- [x] update Heroku runtime to Python 3.7.1
- [x] enable `isolated_build` for tox
- [x] switch from the deprecated `setup.py check` to the new `twine check`
- [x] find a way to use PEP517 for build and deploy to pypi from travis

Travis' `dpl` doesn't yet support the `pyproject.toml` build system: https://github.com/travis-ci/dpl/issues/822
A hack around it is available at https://github.com/jaraco/skeleton/commit/a8bca166266fa2eeab931f6f20eef8e50048dddf

Maybe the best thing to do is wait...