### PR TITLE
Store items substructure so as to not conflict with items method

### DIFF
--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -400,7 +400,7 @@ class Items(SwaggerDict):
         self.format = format
         self.enum = enum
         self.pattern = pattern
-        self.items = items
+        self.items_ = items
         self._insert_extras__()
         _check_type(type, format, enum, pattern, items, self.__class__)
 
@@ -434,7 +434,7 @@ class Parameter(SwaggerDict):
         self.format = format
         self.enum = enum
         self.pattern = pattern
-        self.items = items
+        self.items_ = items
         self.default = default
         self._insert_extras__()
         if (not schema and not type) or (schema and type):
@@ -492,7 +492,7 @@ class Schema(SwaggerDict):
         self.format = format
         self.enum = enum
         self.pattern = pattern
-        self.items = items
+        self.items_ = items
         self.read_only = read_only
         self.default = default
         self._insert_extras__()


### PR DESCRIPTION
The items definition in `Items`, `Parameter` and `Schema` needs to be stored in a field that does not conflict with the standard dictionary `items()` method.