### PR TITLE
Use unambiguous ref names

### DIFF
--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -415,7 +415,7 @@ def get_serializer_ref_name(serializer):
         logger.debug("Forcing inline output for ModelSerializer named 'NestedSerializer':\n" + str(serializer))
         ref_name = None
     else:
-        ref_name = serializer_name
+        ref_name = '{module}.{name}'.format(module=serializer.__module__, name=serializer_name)
         if ref_name.endswith('Serializer'):
             ref_name = ref_name[:-len('Serializer')]
     return ref_name

--- a/testproj/articles/serializers.py
+++ b/testproj/articles/serializers.py
@@ -4,6 +4,10 @@ from rest_framework import serializers
 from articles.models import Article, ArticleGroup
 
 
+class OtherStuffSerializer(serializers.Serializer):
+    bar = serializers.CharField()
+
+
 class ArticleSerializer(serializers.ModelSerializer):
     references = serializers.DictField(
         help_text=_("this is a really bad example"),
@@ -13,12 +17,14 @@ class ArticleSerializer(serializers.ModelSerializer):
     uuid = serializers.UUIDField(help_text="should articles have UUIDs?", read_only=True)
     cover_name = serializers.FileField(use_url=False, source='cover', required=True)
     group = serializers.SlugRelatedField(slug_field='uuid', queryset=ArticleGroup.objects.all())
+    other_stuff = OtherStuffSerializer(required=False)
     original_group = serializers.SlugRelatedField(slug_field='uuid', read_only=True)
 
     class Meta:
         model = Article
         fields = ('title', 'author', 'body', 'slug', 'date_created', 'date_modified',
-                  'references', 'uuid', 'cover', 'cover_name', 'article_type', 'group', 'original_group', )
+                  'references', 'uuid', 'cover', 'cover_name', 'article_type', 'group',
+                  'original_group', 'other_stuff',)
         read_only_fields = ('date_created', 'date_modified',
                             'references', 'uuid', 'cover_name')
         lookup_field = 'slug'

--- a/testproj/users/method_serializers_with_typing.py
+++ b/testproj/users/method_serializers_with_typing.py
@@ -67,3 +67,6 @@ class MethodFieldExampleSerializer(serializers.Serializer):
 
     def get_non_hinted_number(self, obj):
         return 1.0
+
+    class Meta:
+        ref_name = 'user.serializers.MethodFieldExample'

--- a/testproj/users/method_serializers_without_typing.py
+++ b/testproj/users/method_serializers_without_typing.py
@@ -80,3 +80,6 @@ class MethodFieldExampleSerializer(serializers.Serializer):
 
     def get_non_hinted_number(self, obj):
         return 1.0
+
+    class Meta:
+        ref_name = 'user.serializers.MethodFieldExample'

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -91,7 +91,7 @@ paths:
               results:
                 type: array
                 items:
-                  $ref: '#/definitions/Article'
+                  $ref: '#/definitions/articles.serializers.Article'
       tags:
         - articles
     post:
@@ -102,12 +102,12 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Article'
+            $ref: '#/definitions/articles.serializers.Article'
       responses:
         '201':
           description: ''
           schema:
-            $ref: '#/definitions/Article'
+            $ref: '#/definitions/articles.serializers.Article'
       tags:
         - articles
     parameters: []
@@ -132,7 +132,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/Article'
+              $ref: '#/definitions/articles.serializers.Article'
       tags:
         - articles
     parameters: []
@@ -145,7 +145,7 @@ paths:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/Article'
+            $ref: '#/definitions/articles.serializers.Article'
       tags:
         - articles
     put:
@@ -156,7 +156,7 @@ paths:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/Article'
+            $ref: '#/definitions/articles.serializers.Article'
       tags:
         - articles
     patch:
@@ -168,12 +168,12 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Article'
+            $ref: '#/definitions/articles.serializers.Article'
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/Article'
+            $ref: '#/definitions/articles.serializers.Article'
         '404':
           description: slug not found
       tags:
@@ -205,7 +205,7 @@ paths:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/Article'
+            $ref: '#/definitions/articles.serializers.Article'
       consumes:
         - multipart/form-data
       tags:
@@ -244,7 +244,7 @@ paths:
         '201':
           description: ''
           schema:
-            $ref: '#/definitions/ImageUpload'
+            $ref: '#/definitions/articles.serializers.ImageUpload'
       consumes:
         - multipart/form-data
       tags:
@@ -283,7 +283,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/Person'
+              $ref: '#/definitions/people.serializers.Person'
       tags:
         - people
     post:
@@ -294,12 +294,12 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Person'
+            $ref: '#/definitions/people.serializers.Person'
       responses:
         '201':
           description: ''
           schema:
-            $ref: '#/definitions/Person'
+            $ref: '#/definitions/people.serializers.Person'
       tags:
         - people
     parameters: []
@@ -312,7 +312,7 @@ paths:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/Person'
+            $ref: '#/definitions/people.serializers.Person'
       tags:
         - people
     patch:
@@ -323,12 +323,12 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Person'
+            $ref: '#/definitions/people.serializers.Person'
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/Person'
+            $ref: '#/definitions/people.serializers.Person'
       tags:
         - people
     delete:
@@ -355,7 +355,7 @@ paths:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/Identity'
+            $ref: '#/definitions/people.serializers.Identity'
       tags:
         - people
     patch:
@@ -366,12 +366,12 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Identity'
+            $ref: '#/definitions/people.serializers.Identity'
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/Identity'
+            $ref: '#/definitions/people.serializers.Identity'
       tags:
         - people
     parameters:
@@ -401,7 +401,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/Snippet'
+              $ref: '#/definitions/snippets.serializers.Snippet'
       tags:
         - snippets
     post:
@@ -412,12 +412,12 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Snippet'
+            $ref: '#/definitions/snippets.serializers.Snippet'
       responses:
         '201':
           description: ''
           schema:
-            $ref: '#/definitions/Snippet'
+            $ref: '#/definitions/snippets.serializers.Snippet'
       tags:
         - snippets
     delete:
@@ -449,7 +449,7 @@ paths:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/Snippet'
+            $ref: '#/definitions/snippets.serializers.Snippet'
       tags:
         - snippets
     put:
@@ -460,12 +460,12 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Snippet'
+            $ref: '#/definitions/snippets.serializers.Snippet'
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/Snippet'
+            $ref: '#/definitions/snippets.serializers.Snippet'
       tags:
         - snippets
     patch:
@@ -476,12 +476,12 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Snippet'
+            $ref: '#/definitions/snippets.serializers.Snippet'
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/Snippet'
+            $ref: '#/definitions/snippets.serializers.Snippet'
       tags:
         - snippets
     delete:
@@ -515,7 +515,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/Todo'
+              $ref: '#/definitions/todo.serializer.Todo'
       tags:
         - todo
     parameters: []
@@ -530,7 +530,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/TodoAnother'
+              $ref: '#/definitions/todo.serializer.TodoAnother'
       tags:
         - todo
     parameters: []
@@ -543,7 +543,7 @@ paths:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/TodoAnother'
+            $ref: '#/definitions/todo.serializer.TodoAnother'
       tags:
         - todo
     parameters:
@@ -563,7 +563,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/TodoRecursive'
+              $ref: '#/definitions/todo.serializer.TodoRecursive'
       tags:
         - todo
     post:
@@ -574,12 +574,12 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/TodoRecursive'
+            $ref: '#/definitions/todo.serializer.TodoRecursive'
       responses:
         '201':
           description: ''
           schema:
-            $ref: '#/definitions/TodoRecursive'
+            $ref: '#/definitions/todo.serializer.TodoRecursive'
       tags:
         - todo
     parameters: []
@@ -601,12 +601,12 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/TodoRecursive'
+            $ref: '#/definitions/todo.serializer.TodoRecursive'
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/TodoRecursive'
+            $ref: '#/definitions/todo.serializer.TodoRecursive'
       tags:
         - todo
     patch:
@@ -617,12 +617,12 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/TodoRecursive'
+            $ref: '#/definitions/todo.serializer.TodoRecursive'
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/TodoRecursive'
+            $ref: '#/definitions/todo.serializer.TodoRecursive'
       tags:
         - todo
     delete:
@@ -651,7 +651,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/TodoTree'
+              $ref: '#/definitions/todo.serializer.TodoTree'
       tags:
         - todo
     parameters: []
@@ -664,7 +664,7 @@ paths:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/TodoTree'
+            $ref: '#/definitions/todo.serializer.TodoTree'
       tags:
         - todo
     parameters:
@@ -684,7 +684,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/TodoYetAnother'
+              $ref: '#/definitions/todo.serializer.TodoYetAnother'
       tags:
         - todo
     parameters: []
@@ -697,7 +697,7 @@ paths:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/TodoYetAnother'
+            $ref: '#/definitions/todo.serializer.TodoYetAnother'
       tags:
         - todo
     parameters:
@@ -715,7 +715,7 @@ paths:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/Todo'
+            $ref: '#/definitions/todo.serializer.Todo'
       tags:
         - todo
     parameters:
@@ -733,7 +733,7 @@ paths:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/TodoYetAnother'
+            $ref: '#/definitions/todo.serializer.TodoYetAnother'
       tags:
         - todo
     parameters:
@@ -780,7 +780,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/UserSerializerrr'
+              $ref: '#/definitions/users.serializers.UserSerializerrr'
       tags:
         - Users
     post:
@@ -841,7 +841,7 @@ paths:
         '200':
           description: response description
           schema:
-            $ref: '#/definitions/UserSerializerrr'
+            $ref: '#/definitions/users.serializers.UserSerializerrr'
       tags:
         - Users
     put:
@@ -852,12 +852,12 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/UserSerializerrr'
+            $ref: '#/definitions/users.serializers.UserSerializerrr'
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/UserSerializerrr'
+            $ref: '#/definitions/users.serializers.UserSerializerrr'
       tags:
         - Users
     parameters:
@@ -866,7 +866,15 @@ paths:
         required: true
         type: string
 definitions:
-  Article:
+  articles.serializers.OtherStuff:
+    required:
+      - bar
+    type: object
+    properties:
+      bar:
+        type: string
+        minLength: 1
+  articles.serializers.Article:
     required:
       - title
       - body
@@ -941,7 +949,9 @@ definitions:
         type: string
         format: uuid
         readOnly: true
-  ImageUpload:
+      other_stuff:
+        $ref: '#/definitions/articles.serializers.OtherStuff'
+  articles.serializers.ImageUpload:
     required:
       - image_styles
     type: object
@@ -972,7 +982,7 @@ definitions:
         type: string
         readOnly: true
         format: uri
-  Identity:
+  people.serializers.Identity:
     title: Identity
     type: object
     properties:
@@ -993,7 +1003,7 @@ definitions:
         maxLength: 30
         minLength: 1
         x-nullable: true
-  Person:
+  people.serializers.Person:
     required:
       - identity
     type: object
@@ -1003,7 +1013,7 @@ definitions:
         type: integer
         readOnly: true
       identity:
-        $ref: '#/definitions/Identity'
+        $ref: '#/definitions/people.serializers.Identity'
   Project:
     required:
       - projectName
@@ -1020,7 +1030,7 @@ definitions:
         description: Github repository of the project
         type: string
         minLength: 1
-  Snippet:
+  snippets.serializers.Snippet:
     required:
       - code
       - language
@@ -1570,7 +1580,7 @@ definitions:
         format: decimal
         default: 0.0
         minimum: 0.0
-  Todo:
+  todo.serializer.Todo:
     required:
       - title
     type: object
@@ -1580,7 +1590,7 @@ definitions:
         type: string
         maxLength: 50
         minLength: 1
-  TodoAnother:
+  todo.serializer.TodoAnother:
     required:
       - title
       - todo
@@ -1592,8 +1602,8 @@ definitions:
         maxLength: 50
         minLength: 1
       todo:
-        $ref: '#/definitions/Todo'
-  TodoRecursive:
+        $ref: '#/definitions/todo.serializer.Todo'
+  todo.serializer.TodoRecursive:
     required:
       - title
     type: object
@@ -1608,12 +1618,12 @@ definitions:
         maxLength: 50
         minLength: 1
       parent:
-        $ref: '#/definitions/TodoRecursive'
+        $ref: '#/definitions/todo.serializer.TodoRecursive'
       parent_id:
         type: integer
         title: Parent id
         x-nullable: true
-  TodoTree:
+  todo.serializer.TodoTree:
     required:
       - title
       - children
@@ -1631,8 +1641,8 @@ definitions:
       children:
         type: array
         items:
-          $ref: '#/definitions/TodoTree'
-  TodoYetAnother:
+          $ref: '#/definitions/todo.serializer.TodoTree'
+  todo.serializer.TodoYetAnother:
     required:
       - title
     type: object
@@ -1677,7 +1687,7 @@ definitions:
       todo:
         title: child
         todo: null
-  OtherStuff:
+  users.serializers.OtherStuff:
     title: Other stuff
     description: the decorator should determine the serializer class for this
     required:
@@ -1688,7 +1698,7 @@ definitions:
         title: Foo
         type: string
         minLength: 1
-  MethodFieldExample:
+  user.serializers.MethodFieldExample:
     title: Hint example
     type: object
     properties:
@@ -1741,7 +1751,7 @@ definitions:
         description: No hint on the method, so this is expected to fallback to string
         type: string
         readOnly: true
-  UserSerializerrr:
+  users.serializers.UserSerializerrr:
     required:
       - username
       - articles
@@ -1798,9 +1808,9 @@ definitions:
         readOnly: true
         uniqueItems: true
       other_stuff:
-        $ref: '#/definitions/OtherStuff'
+        $ref: '#/definitions/users.serializers.OtherStuff'
       hint_example:
-        $ref: '#/definitions/MethodFieldExample'
+        $ref: '#/definitions/user.serializers.MethodFieldExample'
       help_text_example_1:
         title: Help text example 1
         description: help text on field is set, so this should appear in swagger

--- a/tests/test_reference_schema.py
+++ b/tests/test_reference_schema.py
@@ -52,3 +52,17 @@ def test_no_nested_model(swagger_dict):
     # ForeignKey models in deep ModelViewSets might wrongly be labeled as 'Nested' in the definitions section
     # see https://github.com/axnsan12/drf-yasg/issues/59
     assert 'Nested' not in swagger_dict['definitions']
+
+
+def test_same_name_serializers(swagger_dict):
+    article_definition = swagger_dict['definitions']['articles.serializers.Article']
+    assert article_definition['properties']['other_stuff']['$ref'] == '#/definitions/articles.serializers.OtherStuff'
+    articles_other_stuff_definition = swagger_dict['definitions']['articles.serializers.OtherStuff']
+    assert 'foo' not in articles_other_stuff_definition['properties']
+    assert 'bar' in articles_other_stuff_definition['properties']
+
+    user_definition = swagger_dict['definitions']['users.serializers.UserSerializerrr']
+    assert user_definition['properties']['other_stuff']['$ref'] == '#/definitions/users.serializers.OtherStuff'
+    users_other_stuff_definition = swagger_dict['definitions']['users.serializers.OtherStuff']
+    assert 'foo' in users_other_stuff_definition['properties']
+    assert 'bar' not in users_other_stuff_definition['properties']

--- a/tests/test_schema_generator.py
+++ b/tests/test_schema_generator.py
@@ -119,11 +119,11 @@ def test_replaced_serializer():
 
     for _ in range(3):
         swagger = generator.get_schema(None, True)
-        assert 'Detail' in swagger['definitions']
-        assert 'detail' in swagger['definitions']['Detail']['properties']
+        assert 'test_schema_generator.Detail' in swagger['definitions']
+        assert 'detail' in swagger['definitions']['test_schema_generator.Detail']['properties']
         responses = swagger['paths']['/details/{id}/']['get']['responses']
         assert '404' in responses
-        assert responses['404']['schema']['$ref'] == "#/definitions/Detail"
+        assert responses['404']['schema']['$ref'] == "#/definitions/test_schema_generator.Detail"
 
 
 def test_url_order():
@@ -226,6 +226,6 @@ def test_choice_field(choices, expected_type):
     )
 
     swagger = generator.get_schema(None, True)
-    property_schema = swagger['definitions']['Detail']['properties']['detail']
+    property_schema = swagger['definitions']['test_schema_generator.Detail']['properties']['detail']
 
     assert property_schema == openapi.Schema(title='Detail', type=expected_type, enum=choices)

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -28,8 +28,8 @@ def _check_base(swagger, prefix, validate_schema):
 def _check_v1(swagger):
     assert swagger['info']['version'] == '1.0'
     versioned_post = swagger['paths']['/snippets/']['post']
-    assert versioned_post['responses']['201']['schema']['$ref'] == '#/definitions/Snippet'
-    assert 'v2field' not in swagger['definitions']['Snippet']['properties']
+    assert versioned_post['responses']['201']['schema']['$ref'] == '#/definitions/snippets.serializers.Snippet'
+    assert 'v2field' not in swagger['definitions']['snippets.serializers.Snippet']['properties']
 
 
 def _check_v2(swagger):


### PR DESCRIPTION
serializer type name may be ambiguous, e.g. in different applications of the same project one may have different `Account` with the same serializer class name but with different fields, etc.
In current implementation they will have the same `$ref` name in API spec which will lead to improper API representation.
Adding module name to ref name should solve this problem.