### PR TITLE
Support RecursiveField with 'many' option

### DIFF
--- a/testproj/todo/serializer.py
+++ b/testproj/todo/serializer.py
@@ -41,10 +41,11 @@ class TodoYetAnotherSerializer(serializers.ModelSerializer):
 
 class TodoTreeSerializer(serializers.ModelSerializer):
     children = serializers.ListField(child=RecursiveField(), source='children.all')
+    many_children = RecursiveField(many=True, source='children')
 
     class Meta:
         model = TodoTree
-        fields = ('id', 'title', 'children')
+        fields = ('id', 'title', 'children', 'many_children')
 
 
 class TodoRecursiveSerializer(serializers.ModelSerializer):

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -1617,6 +1617,7 @@ definitions:
     required:
       - title
       - children
+      - many_children
     type: object
     properties:
       id:
@@ -1629,6 +1630,10 @@ definitions:
         maxLength: 50
         minLength: 1
       children:
+        type: array
+        items:
+          $ref: '#/definitions/TodoTree'
+      many_children:
         type: array
         items:
           $ref: '#/definitions/TodoTree'


### PR DESCRIPTION
suddenly, we needed this for the case when recursive field was actually referencing not the parent serializer, but the one defined later in the same module