### PR TITLE
feat: add is_list option to view action method

### DIFF
--- a/src/drf_yasg/inspectors/base.py
+++ b/src/drf_yasg/inspectors/base.py
@@ -412,7 +412,7 @@ class ViewInspector(BaseInspector):
             return False
 
         if self.method.lower() != 'get':
-            return False
+            return self.overrides.get('should_page', False)
 
         return is_list_view(self.path, self.method, self.view)
 

--- a/src/drf_yasg/inspectors/view.py
+++ b/src/drf_yasg/inspectors/view.py
@@ -208,7 +208,8 @@ class SwaggerAutoSchema(ViewInspector):
             default_schema = self.serializer_to_schema(default_schema) or ''
 
         if default_schema:
-            if is_list_view(self.path, self.method, self.view) and self.method.lower() == 'get':
+            if self.overrides.get('is_list', False) or\
+                (is_list_view(self.path, self.method, self.view) and self.method.lower() == 'get'):
                 default_schema = openapi.Schema(type=openapi.TYPE_ARRAY, items=default_schema)
             if self.should_page():
                 default_schema = self.get_paginated_response(default_schema) or default_schema

--- a/src/drf_yasg/inspectors/view.py
+++ b/src/drf_yasg/inspectors/view.py
@@ -208,10 +208,12 @@ class SwaggerAutoSchema(ViewInspector):
             default_schema = self.serializer_to_schema(default_schema) or ''
 
         if default_schema:
-            if self.overrides.get('is_list', False) or\
+            is_list = self.overrides.get('is_list', False)
+            should_page = self.overrides.get('should_page', False)
+            if (is_list or should_page) or\
                 (is_list_view(self.path, self.method, self.view) and self.method.lower() == 'get'):
                 default_schema = openapi.Schema(type=openapi.TYPE_ARRAY, items=default_schema)
-            if self.should_page():
+            if should_page or self.should_page():
                 default_schema = self.get_paginated_response(default_schema) or default_schema
 
         return OrderedDict({str(default_status): default_schema})

--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -217,6 +217,9 @@ def is_list_view(path, method, view):
     # for ViewSets, it could be the default 'list' action, or a list_route
     action = getattr(view, 'action', '')
     method = getattr(view, action, None) or method
+    is_list = getattr(method,'is_list', False)
+    if is_list:
+        return True
     detail = getattr(method, 'detail', None)
     suffix = getattr(view, 'suffix', None)
     if action in ('list', 'create') or detail is False or suffix == 'List':

--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -217,7 +217,7 @@ def is_list_view(path, method, view):
     # for ViewSets, it could be the default 'list' action, or a list_route
     action = getattr(view, 'action', '')
     method = getattr(view, action, None) or method
-    is_list = getattr(method,'is_list', False)
+    is_list = getattr(method, 'is_list', False)
     if is_list:
         return True
     detail = getattr(method, 'detail', None)


### PR DESCRIPTION
I struggled a day try to add drf-yasg for a exists project.
First I found drf-yasg generate unintented schema.
our TopicViewSet as follows:( one Topic  have many Posts)

```py3
class TopicViewSet(viewsets.ModelViewSet):
    queryset = Topic.objects.all()
    serializer_class = TopicSerializer
    permission_classes = (DjangoModelPermissionsOrAnonReadOnly,)

    @action(detail=True)
    def posts(self, request:HttpRequest, pk) -> Response:
        pits = PostInTopic.objects.filter(topic_id=pk).all()
        page = self.paginate_queryset(pits)
        if page is not None:
            serializer = PostInTopicSerializer(page, many=True)
            return self.get_paginated_response(serializer.data)

        serializer = PostInTopicSerializer(pits, many=True)
        return Response(serializer.data)
```

in order to make drf-yasg generate right schema for posts actions. I have debug a lot and read drf-yasg's source code.
and I found:
1. `detail=True` can't set to `False` because We need the `pk` parameter.
2. if `detail=True` then we can't return paginated response schema.

My finally code was as below:

```py
class TopicViewSet(viewsets.ModelViewSet):
    queryset = Topic.objects.all()
    serializer_class = TopicSerializer
    permission_classes = (DjangoModelPermissionsOrAnonReadOnly,)

    @action(detail=True)
    def posts(self, request: HttpRequest, pk: int) -> Response:
        pits = PostInTopic.objects.filter(topic_id=pk).all()
        page = self.paginate_queryset(pits)
        if page is not None:
            serializer = self.get_serializer(page, many=True)
            return self.get_paginated_response(serializer.data)

        serializer = self.get_serializer(pits, many=True)
        return Response(serializer.data)

    posts.is_list = True # we do return list response

    def get_serializer_class(self):
        #  drf_yasf  will call get_serializer()
        if self.action == "posts":
            return PostInTopicSerializer
        return super().get_serializer_class()
```

and I have to midify the drf-yasg source code, I think it would be very useful to add optional `is_list` flag for view action method.

I've checked our project,there are many places, I need to use `is_list` option to make drf-yasg work correctly.
