### PR TITLE
generators: support custom ReferenceResolver class

### DIFF
--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -160,6 +160,7 @@ class OpenAPISchemaGenerator(object):
     Method implementations shamelessly stolen and adapted from rest-framework ``SchemaGenerator``.
     """
     endpoint_enumerator_class = EndpointEnumerator
+    reference_resolver_class = ReferenceResolver
 
     def __init__(self, info, version='', url=None, patterns=None, urlconf=None):
         """
@@ -238,7 +239,7 @@ class OpenAPISchemaGenerator(object):
         :rtype: openapi.Swagger
         """
         endpoints = self.get_endpoints(request)
-        components = ReferenceResolver(openapi.SCHEMA_DEFINITIONS, force_init=True)
+        components = self.reference_resolver_class(openapi.SCHEMA_DEFINITIONS, force_init=True)
         self.consumes = get_consumes(api_settings.DEFAULT_PARSER_CLASSES)
         self.produces = get_produces(api_settings.DEFAULT_RENDERER_CLASSES)
         paths, prefix = self.get_paths(endpoints, components, request, public)


### PR DESCRIPTION
I need to override the logic of the ReferenceResolver class.

My customized ReferenceResolver looks like:
```
class StandardizedReferenceResolver(ReferenceResolver):
    def set(self, name, obj, scope=None):
        scope = self._check_scope(scope)
        assert obj is not None, "referenced objects cannot be None/null"
        self._objects[scope][name] = obj

    def setdefault(self, name, maker, scope=None):
        scope = self._check_scope(scope)
        ret = self.getdefault(name, None, scope)
        if ret is None:
            ret = maker()
            value = self.getdefault(name, None, scope)
            if value is None:
                self.set(name, ret, scope)
            elif value != ret and len(ret.properties) > len(value.properties):
                self.set(name, ret, scope)
            elif value != ret:
                logger.debug("during setdefault, maker for %s inserted a "
                             "value and returned a different value", name)
                ret = value
        return ret

    def with_scope(self, scope):
        assert scope in self.scopes, "unknown scope %s" % scope
        ret = StandardizedReferenceResolver(force_init=True)
        ret._objects = self._objects
        ret._force_scope = scope
        return ret
```

With that fix I can use:
```
from drf_yasg.generators import OpenAPISchemaGenerator

class StandardizedSchemaGenerator(OpenAPISchemaGenerator):
    reference_resolver_class = StandardizedReferenceResolver
```