### PR TITLE
Fix unicode attribute error if typing backport installed on python2.7

### DIFF
--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -2,6 +2,7 @@ import datetime
 import inspect
 import logging
 import operator
+import sys
 import uuid
 from collections import OrderedDict
 from decimal import Decimal
@@ -488,6 +489,9 @@ hinting_type_info = [
     (datetime.datetime, (openapi.TYPE_STRING, openapi.FORMAT_DATETIME)),
     (datetime.date, (openapi.TYPE_STRING, openapi.FORMAT_DATE)),
 ]
+
+if sys.version_info < (3, 0):
+    hinting_type_info.append((unicode, (openapi.TYPE_STRING, None)))
 
 if typing:
     def inspect_collection_hint_class(hint_class):

--- a/testproj/users/serializers.py
+++ b/testproj/users/serializers.py
@@ -1,3 +1,5 @@
+import sys
+
 from django.contrib.auth.models import User
 from rest_framework import serializers
 
@@ -6,7 +8,10 @@ from snippets.models import Snippet
 
 try:
     import typing  # noqa: F401
-    from .method_serializers_with_typing import MethodFieldExampleSerializer
+    if sys.version_info >= (3, 4):
+        from .method_serializers_with_typing import MethodFieldExampleSerializer
+    else:
+        from .method_serializers_without_typing import MethodFieldExampleSerializer
 except ImportError:
     from .method_serializers_without_typing import MethodFieldExampleSerializer
 

--- a/tests/test_schema_generator.py
+++ b/tests/test_schema_generator.py
@@ -204,6 +204,7 @@ def test_action_mapping():
 
 @pytest.mark.parametrize('choices, expected_type', [
     (['A', 'B'], openapi.TYPE_STRING),
+    ([u'A', u'B'], openapi.TYPE_STRING),
     ([123, 456], openapi.TYPE_INTEGER),
     ([1.2, 3.4], openapi.TYPE_NUMBER),
     (['A', 456], openapi.TYPE_STRING)

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ isolated_build_env = .package
 
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 envlist =
+    py27-django111-drf39-typing,
     py{27,34,35,36}-django111-drf{37,38,39},
     py{34,35,36,37}-django20-drf{37,38,39},
     py{35,36,37}-django21-drf{37,38,39},
@@ -25,6 +26,8 @@ deps =
     drf37: djangorestframework>=3.7.7,<3.8
     drf38: djangorestframework>=3.8.0,<3.9
     drf39: djangorestframework>=3.9,<3.10
+
+    typing: typing>=3.6.6
 
     # test with the latest build of django-rest-framework to get early warning of compatibility issues
     djmaster: https://github.com/encode/django-rest-framework/archive/master.tar.gz


### PR DESCRIPTION
Python2.7 with Typing backport module installed throws `AttributeError: type object 'unicode' has no attribute '__args__'` this is because this commit https://github.com/axnsan12/drf-yasg/commit/7bb4700003561b7bb6846d69866e69452830b916 calls `json.loads(json.dumps(value))` which returns unicode strings in Python2.7 and the `hinting_type_info` does not have unicode in the list (assuming because unicode is no longer a class in Python3) but if the typing module is installed it will think that the unicode type class is a collection and will call `inspect_collection_hint_class` in field.py.

Also I had to change the testproject slightly in order to get the tests to run with the typing backport installed as the typing style is not supported on python2

Not sure what the correct way of checking Python version is but I think there is enough information here to get a better solution if this is not the correct style for this project.