### PR TITLE
handle enum type for nested ChoiceFields

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,5 +5,7 @@ pytest-cov>=2.6.0
 pytest-xdist>=1.25.0
 pytest-django>=3.4.4
 datadiff==2.0.0
+psycopg2-binary==2.8.3
+django-fake-model==0.1.4
 
 -r testproj.txt

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -656,7 +656,11 @@ class ChoiceFieldInspector(FieldInspector):
             serializer = get_parent_serializer(field)
             if isinstance(serializer, serializers.ModelSerializer):
                 model = getattr(getattr(serializer, 'Meta'), 'model')
-                model_field = get_model_field(model, field.source)
+                # Use the parent source for nested fields
+                model_field = get_model_field(model, field.source or field.parent.source)
+                # If the field has a base_field its type must be used
+                if getattr(model_field, "base_field", None):
+                    model_field = model_field.base_field
                 if model_field:
                     model_type = get_basic_type_info(model_field)
                     if model_type:


### PR DESCRIPTION
Hello,

On a project I'm working on, I'm using Django `IntegerField`s, with a `choices` parameter, nested in postgres `ArrayFields`. This translates to a `ListField` with a child `ChoiceField` in the `ModelSerializer`.

The issue I'm having is that `ChoiceFieldInspector` fails to properly infer the resulting enum type, even though it could because it can guess it correctly for `IntegerField`s:

- First, it tries to get the corresponding model field, but since the nested `ChoiceField` has no `source`, it fails. I fixed it by using `parent.source`.
- Then, even if it manages to get the corresponding model field, it's an `ArrayField` so `get_basic_type_info` doesn't return anything. I fixed it by using the `base_field` if present.

This PR adds some code that fixes the issue & a test. Feel free to tell me if I solved the problem the wrong way; tests seem to pass so I don't think I broke anything.

