### PR TITLE
Fix imports for upcoming DRF version

### DIFF
--- a/requirements/testproj.txt
+++ b/requirements/testproj.txt
@@ -3,7 +3,9 @@ Pillow>=4.3.0
 django-cors-headers>=2.1.0
 django-filter>=1.1.0,<2.0; python_version == "2.7"
 django-filter>=1.1.0; python_version >= "3.5"
-djangorestframework-camel-case>=0.2.0
+#djangorestframework-camel-case>=0.2.0
+# tempory replacement of broken lib
+-e git+https://github.com/tfranzel/djangorestframework-camel-case.git@bd556d38fa7382acadfe91d93d92d99c663248a9#egg=djangorestframework_camel_case
 djangorestframework-recursive>=0.1.2
 dj-database-url>=0.4.2
 user_agents>=1.1.0

--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -4,14 +4,22 @@ import re
 from collections import OrderedDict, defaultdict
 
 import uritemplate
+import rest_framework
 from coreapi.compat import urlparse
 from rest_framework import versioning
 from rest_framework.compat import URLPattern, URLResolver, get_original_route
-from rest_framework.schemas import SchemaGenerator
 from rest_framework.schemas.generators import EndpointEnumerator as _EndpointEnumerator
 from rest_framework.schemas.generators import endpoint_ordering, get_pk_name
-from rest_framework.schemas.utils import get_pk_description
+
 from rest_framework.settings import api_settings
+
+from packaging.version import Version
+if Version(rest_framework.__version__) < Version('3.10'):
+    from rest_framework.schemas.generators import SchemaGenerator
+    from rest_framework.schemas.inspectors import get_pk_description
+else:
+    from rest_framework.schemas import SchemaGenerator
+    from rest_framework.schemas.utils import get_pk_description
 
 from . import openapi
 from .app_settings import swagger_settings

--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -7,9 +7,10 @@ import uritemplate
 from coreapi.compat import urlparse
 from rest_framework import versioning
 from rest_framework.compat import URLPattern, URLResolver, get_original_route
+from rest_framework.schemas import SchemaGenerator
 from rest_framework.schemas.generators import EndpointEnumerator as _EndpointEnumerator
-from rest_framework.schemas.generators import SchemaGenerator, endpoint_ordering, get_pk_name
-from rest_framework.schemas.inspectors import get_pk_description
+from rest_framework.schemas.generators import endpoint_ordering, get_pk_name
+from rest_framework.schemas.utils import get_pk_description
 from rest_framework.settings import api_settings
 
 from . import openapi

--- a/testproj/snippets/serializers.py
+++ b/testproj/snippets/serializers.py
@@ -1,8 +1,8 @@
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model
+from django.core.validators import MaxLengthValidator, MinValueValidator
 from rest_framework import serializers
-from rest_framework.compat import MaxLengthValidator, MinValueValidator
 
 from snippets.models import LANGUAGE_CHOICES, STYLE_CHOICES, Snippet, SnippetViewer
 

--- a/testproj/snippets/serializers.py
+++ b/testproj/snippets/serializers.py
@@ -1,7 +1,12 @@
+import rest_framework
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model
-from django.core.validators import MaxLengthValidator, MinValueValidator
+from packaging.version import Version
+if Version(rest_framework.__version__) < Version('3.10'):
+    from rest_framework.compat import MaxLengthValidator, MinValueValidator
+else:
+    from django.core.validators import MaxLengthValidator, MinValueValidator
 from rest_framework import serializers
 
 from snippets.models import LANGUAGE_CHOICES, STYLE_CHOICES, Snippet, SnippetViewer

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     py27-django111-drf{38,39},
     py{35,36}-django{111,21,22}-drf{38,39},
     py37-django{21,22}-drf{38,39},
+    py37-django{21,22}-drf310,
     djmaster, lint, docs
 
 [testenv:.package]
@@ -23,6 +24,7 @@ deps =
 
     drf38: djangorestframework>=3.8,<3.9
     drf39: djangorestframework>=3.9,<3.10
+    drf310: djangorestframework>=3.10
 
     typing: typing>=3.6.6
 


### PR DESCRIPTION
Came across this while working on a PR for DRF. Upstream changes to DRF will break drf-yasg with the release of [3.10](https://github.com/encode/django-rest-framework/tree/version-3.10). DRF is dropping Py2 support and did some refactorings.

Tests worked fine with DRF branch `version-3.10` installed in the virtualenv

[breaking DRF PR](https://github.com/encode/django-rest-framework/pull/6532)

Sidenote: I also had to create a PR for the dependency [djangorestframework-camel-case](https://github.com/vbabiy/djangorestframework-camel-case/pull/58) as it will also break on 3.10.

