### PR TITLE
Avoid moving up to ruamel.yaml 0.16.x

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 coreapi>=2.3.3
 coreschema>=0.0.4
-ruamel.yaml>=0.15.34
+ruamel.yaml~=0.15.34
 inflection>=0.3.1
 six>=1.10.0
 uritemplate>=3.0.0


### PR DESCRIPTION
Following the usual semver rules, pre 1.0 packages may have breaking changes between minor versions, so it makes sense to pin to >=0.15.34 and <0.16.0, which is most easily expressed with the "compatible release" operator, ~=.

See #423.