### PR TITLE
Support multipart media type by default for filefield/imagefield

### DIFF
--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -374,8 +374,12 @@ def get_consumes(parser_classes):
     parser_classes = [pc for pc in parser_classes if not issubclass(pc, FileUploadParser)]
     media_types = [parser.media_type for parser in parser_classes or []]
     non_form_media_types = [encoding for encoding in media_types if not is_form_media_type(encoding)]
+    # Because some data to parse could be nested array and are not supported by form media type like multipart/form-data,
+    # we must be sure to have explicit form media types **only**.
     if len(non_form_media_types) == 0:
         return media_types
+    # Otherwise, enforce a media type like application/json to be able to parse nested array, but it won't be able to
+    # support file upload...
     else:
         return non_form_media_types
 


### PR DESCRIPTION
See issue https://github.com/axnsan12/drf-yasg/issues/386

With that fix, it means that we may always use Multipart media type instead of JSON parser... So not really sure if it is a good idea or not :/

A better alternative would be to have to select the content type in the UI of Swagger or Redoc instead....