### PR TITLE
Support field level examples

### DIFF
--- a/src/drf_yasg/inspectors/base.py
+++ b/src/drf_yasg/inspectors/base.py
@@ -198,8 +198,9 @@ class FieldInspector(BaseInspector):
         self.field_inspectors = field_inspectors
 
     def add_manual_fields(self, serializer_or_field, schema):
-        """Set fields from the ``swagger_schem_fields`` attribute on the Meta class. This method is called
-        only for serializers or fields that are converted into ``openapi.Schema`` objects.
+        """Set fields from the ``swagger_schema_fields`` and ``swagger_schema_examples`` attribute on 
+        the Meta class. This method is called only for serializers or fields that are converted into 
+        ``openapi.Schema`` objects.
 
         :param serializer_or_field: serializer or field instance
         :param openapi.Schema schema: the schema object to be modified in-place
@@ -209,6 +210,15 @@ class FieldInspector(BaseInspector):
         if swagger_schema_fields:
             for attr, val in swagger_schema_fields.items():
                 setattr(schema, attr, val)
+                
+        
+        swagger_schema_examples = getattr(meta, 'swagger_schema_examples', {})
+        if not swagger_schema_examples or 'properties' not in schema:
+            return
+        for attr, val in swagger_schema_examples.items():
+            if attr not in schema['properties']:
+                continue
+            schema['properties'][attr]['example'] = val
 
     def field_to_swagger_object(self, field, swagger_object_type, use_references, **kwargs):
         """Convert a drf Serializer or Field instance into a Swagger object.

--- a/testproj/users/serializers.py
+++ b/testproj/users/serializers.py
@@ -19,6 +19,11 @@ except ImportError:
 class OtherStuffSerializer(serializers.Serializer):
     foo = serializers.CharField()
 
+    class Meta:
+        swagger_schema_examples = {
+            'foo': 'bar'
+        }
+
 
 class UserSerializerrr(serializers.ModelSerializer):
     snippets = serializers.PrimaryKeyRelatedField(many=True, queryset=Snippet.objects.all())

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -1377,6 +1377,7 @@ definitions:
         title: Foo
         type: string
         minLength: 1
+        example: bar
   MethodFieldExample:
     title: Hint example
     type: object


### PR DESCRIPTION
Add support for field-level examples from meta class  …

This code allows us to add field-level `example`s. Usage:

```python
class SomeSerializer(serializers.Serializer):
    some_date = serializers.DateField()

    class Meta:
        swagger_schema_examples = {
            'some_date': '2000-01-15'
        }
```