### PR TITLE
Edit type check for swagger_auto_schema (specifically for the `responses` param)

### DIFF
--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -95,8 +95,8 @@ def swagger_auto_schema(method=None, methods=None, auto_schema=unset, request_bo
         * a ``Serializer`` class or instance will be converted into a :class:`.Schema` and treated as above
         * a :class:`.Response` object will be used as-is; however if its ``schema`` attribute is a ``Serializer``,
           it will automatically be converted into a :class:`.Schema`
-    :type responses: dict[str,(drf_yasg.openapi.Schema or drf_yasg.openapi.SchemaRef or drf_yasg.openapi.Response or
-        str or rest_framework.serializers.Serializer)]
+    :type responses: dict[int or str, (drf_yasg.openapi.Schema or drf_yasg.openapi.SchemaRef or
+        drf_yasg.openapi.Response or str or rest_framework.serializers.Serializer)]
 
     :param list[type[drf_yasg.inspectors.FieldInspector]] field_inspectors: extra serializer and field inspectors; these
         will be tried before :attr:`.ViewInspector.field_inspectors` on the :class:`.inspectors.SwaggerAutoSchema`


### PR DESCRIPTION
Hello,

I use PyCharm and the `swagger_auto_schema` util has been causing **type-check** related warnings like the following *(see yellow box)*

![image](https://user-images.githubusercontent.com/37664182/68573971-39460e80-04ac-11ea-84d8-1e49deaf1658.png)
(*sorry for lame screenshot..*)

Although the convention seems to be to use *integer* keys for the `responses` dict to pass to `swagger_auto_schema` ([reference](https://drf-yasg.readthedocs.io/en/stable/custom_spec.html#the-swagger-auto-schema-decorator)), type-checking was being done to enforce keys to be `str` in the code.

So I edited to allow both `int or str` types for the keys of the `responses` dict.

Not an important issue, but the warning in PyCharm was getting pretty annoying, so I made this PR..
Hope this  helps!