### PR TITLE
Allow users to specify collectionFormat for ListFields (& ListSerializers)

### DIFF
--- a/src/drf_yasg/app_settings.py
+++ b/src/drf_yasg/app_settings.py
@@ -69,6 +69,7 @@ SWAGGER_DEFAULTS = {
         'trace'
     ],
     'DISPLAY_OPERATION_ID': True,
+    'COLLECTION_FORMAT': None,
 }
 
 REDOC_DEFAULTS = {

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -39,7 +39,7 @@ class InlineSerializerInspector(SerializerInspector):
     #: whether to output :class:`.Schema` definitions inline or into the ``definitions`` section
     use_definitions = False
     #: which collectionFormat to use for ListFields & ListSerializers
-    collection_format = swagger_settings.COLLECTION_FORMAT
+    collection_format = swagger_settings.COLLECTION_FORMAT or None
 
     def get_schema(self, serializer):
         return self.probe_field_inspectors(serializer, openapi.Schema, self.use_definitions)

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -93,9 +93,9 @@ class InlineSerializerInspector(SerializerInspector):
                 items=child_schema,
                 **limits
             )
-            if swagger_object_type == openapi.Parameter:
-                if result['in'] in (openapi.IN_FORM, openapi.IN_QUERY):
-                    if self.collection_format:
+            if self.collection_format:
+                if swagger_object_type == openapi.Parameter:
+                    if result['in'] in (openapi.IN_FORM, openapi.IN_QUERY):
                         result.collection_format = self.collection_format
             return result
 


### PR DESCRIPTION
Hello (again),

While using this (very helpful) package, I needed swagger to use `collectionFormat: multi` for my `ListField`'s. I wrote this quick fix up (using [this](https://github.com/axnsan12/drf-yasg/commit/708e70a52645ba62ddf8f7776022c82dd010bc94) as reference), and I'm using this edited version of the package for my django development.

I'm putting in this PR for future ppls that may need such a feature.

**I.e., I made edits so that if your project includes the setting (in `base.py`):**
```py
SWAGGER_SETTINGS = {
    # ...
    'COLLECTION_FORMAT': 'multi',
    # ...
}
```
**then requests made in swagger ui page with `ListField` parameters are rendered as:**
`.../?field=value1&field=value2` **instead of the default** `.../?field=value1,value2`

Please feel free to edit the implementation or even decline the PR as you wish!