### PR TITLE
Allow working with coreschema subclasses

### DIFF
--- a/src/drf_yasg/inspectors/query.py
+++ b/src/drf_yasg/inspectors/query.py
@@ -38,21 +38,27 @@ class CoreAPICompatInspector(PaginatorInspector, FilterInspector):
             'form': openapi.IN_FORM,
             'body': openapi.IN_FORM,
         }
-        coreapi_types = {
-            coreschema.Integer: openapi.TYPE_INTEGER,
-            coreschema.Number: openapi.TYPE_NUMBER,
-            coreschema.String: openapi.TYPE_STRING,
-            coreschema.Boolean: openapi.TYPE_BOOLEAN,
-        }
 
         coreschema_attrs = ['format', 'pattern', 'enum', 'min_length', 'max_length']
         schema = field.schema
+
+        type_ = openapi.TYPE_STRING
+        for coreschema_type, openapi_type in (
+            (coreschema.Integer, openapi.TYPE_INTEGER),
+            (coreschema.Number, openapi.TYPE_NUMBER),
+            (coreschema.String, openapi.TYPE_STRING),
+            (coreschema.Boolean, openapi.TYPE_BOOLEAN),
+        ):
+            if isinstance(schema, coreschema_type):
+                type_ = openapi_type
+                break
+
         return openapi.Parameter(
             name=field.name,
             in_=location_to_in[field.location],
             required=field.required,
             description=force_real_str(schema.description) if schema else None,
-            type=coreapi_types.get(type(schema), openapi.TYPE_STRING),
+            type=type_,
             **OrderedDict((attr, getattr(schema, attr, None)) for attr in coreschema_attrs)
         )
 


### PR DESCRIPTION
I'm currently working with some custom coreschema for my APIs by sub-classing the existing ones. As I'm migrating to OpenAPI (the coreschema compat was a life saver :heart:), found that drf-yasg doesn't catch these cases and falls back to strings. 

This should help out for any cases where subclasses are used for coreschema definitions. 
