### PR TITLE
Fix duration field inspector

### DIFF
--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -380,7 +380,7 @@ model_field_to_basic_type = [
     (models.DateTimeField, (openapi.TYPE_STRING, openapi.FORMAT_DATETIME)),
     (models.DateField, (openapi.TYPE_STRING, openapi.FORMAT_DATE)),
     (models.DecimalField, (decimal_field_type, openapi.FORMAT_DECIMAL)),
-    (models.DurationField, (openapi.TYPE_INTEGER, None)),
+    (models.DurationField, (openapi.TYPE_STRING, None)),
     (models.FloatField, (openapi.TYPE_NUMBER, None)),
     (models.IntegerField, (openapi.TYPE_INTEGER, None)),
     (models.IPAddressField, (openapi.TYPE_STRING, openapi.FORMAT_IPV4)),
@@ -407,7 +407,7 @@ serializer_field_to_basic_type = [
     (serializers.IntegerField, (openapi.TYPE_INTEGER, None)),
     (serializers.FloatField, (openapi.TYPE_NUMBER, None)),
     (serializers.DecimalField, (decimal_field_type, openapi.FORMAT_DECIMAL)),
-    (serializers.DurationField, (openapi.TYPE_NUMBER, None)),  # ?
+    (serializers.DurationField, (openapi.TYPE_STRING, None)),
     (serializers.DateField, (openapi.TYPE_STRING, openapi.FORMAT_DATE)),
     (serializers.DateTimeField, (openapi.TYPE_STRING, openapi.FORMAT_DATETIME)),
     (serializers.ModelField, (openapi.TYPE_STRING, None)),


### PR DESCRIPTION
Durations should be represented as an `openapi.TYPE_STRING` so swagger and other tools do not prevent valid input ("00:10:00" is valid, but not a number)

See:

https://www.django-rest-framework.org/api-guide/fields/#durationfield and
https://docs.djangoproject.com/en/3.0/ref/utils/#django.utils.dateparse.parse_duration