### PR TITLE
Fix django-oauth-toolkit library related error when db migrating testproj

### DIFF
--- a/requirements/testproj.txt
+++ b/requirements/testproj.txt
@@ -7,3 +7,4 @@ djangorestframework-recursive>=0.1.2
 dj-database-url>=0.4.2
 user_agents>=1.1.0
 django-cors-headers
+django-oauth-toolkit>=1.3.0

--- a/testproj/users/migrations/0002_setup_oauth2_apps.py
+++ b/testproj/users/migrations/0002_setup_oauth2_apps.py
@@ -30,7 +30,7 @@ def add_oauth_apps(apps, schema_editor):
 class Migration(migrations.Migration):
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('oauth2_provider', '0006_auto_20171214_2232'),
+        ('oauth2_provider', '0002_auto_20190406_1805'),
         ('users', '0001_create_admin_user'),
     ]
 


### PR DESCRIPTION
Fixed an error that occurred when `python manage.py migrate` in `testproj`

- Fix #563
  - Add django-oauth-toolkit to requirements/testproj.txt
  - Fixed oauth2_provider dependency in testproj/users/migrations/0002