### PR TITLE
Fix x-nullable on serializers with `allow_null=True`

### DIFF
--- a/src/drf_yasg/inspectors/base.py
+++ b/src/drf_yasg/inspectors/base.py
@@ -289,7 +289,7 @@ class FieldInspector(BaseInspector):
                 instance_kwargs.setdefault('title', title)
             if description is not None:
                 instance_kwargs.setdefault('description', description)
-            if field.allow_null and not instance_kwargs.get('required', False) and not field.required:
+            if field.allow_null:
                 instance_kwargs['x_nullable'] = True
 
             instance_kwargs.update(kwargs)

--- a/testproj/snippets/models.py
+++ b/testproj/snippets/models.py
@@ -16,6 +16,10 @@ class Snippet(models.Model):
     class Meta:
         ordering = ('created',)
 
+    @property
+    def nullable_secondary_language(self):
+        return None
+
 
 class SnippetViewer(models.Model):
     snippet = models.ForeignKey(Snippet, on_delete=models.CASCADE, related_name='viewers')

--- a/testproj/snippets/serializers.py
+++ b/testproj/snippets/serializers.py
@@ -86,6 +86,8 @@ class SnippetSerializer(serializers.Serializer):
     rate = serializers.DecimalField(max_digits=6, decimal_places=3, default=Decimal('0.0'), coerce_to_string=False,
                                     validators=[MinValueValidator(Decimal('0.0'))])
 
+    nullable_secondary_language = LanguageSerializer(allow_null=True)
+
     def create(self, validated_data):
         """
         Create and return a new `Snippet` instance, given the validated data.

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -1130,6 +1130,7 @@ definitions:
       - code
       - tags
       - language
+      - nullableSecondaryLanguage
     type: object
     properties:
       id:
@@ -1230,6 +1231,25 @@ definitions:
         format: decimal
         default: 0.0
         minimum: 0.0
+      nullableSecondaryLanguage:
+        type: object
+        properties:
+          name:
+            title: Name
+            description: The name of the programming language
+            type: string
+            enum:
+              - cpp
+              - js
+              - python
+            default: python
+          readOnlyNullable:
+            title: Read only nullable
+            type: string
+            readOnly: true
+            minLength: 1
+            x-nullable: true
+        x-nullable: true
   SnippetViewer:
     required:
       - snippet


### PR DESCRIPTION
This PR allows `x-nullable` on serializers. As originally implemented in #217 I believe this was too strict. The `required` `instance_kwargs` in this context are the fields that are required *not* if the field is required or not. According to the openapi spec the parent should be managing if the child is required and therefore this shouldn't even be checking `field.required` either.