### PR TITLE
Do not use field label for top level definition titles

### DIFF
--- a/src/drf_yasg/inspectors/base.py
+++ b/src/drf_yasg/inspectors/base.py
@@ -276,7 +276,7 @@ class FieldInspector(BaseInspector):
         description = force_real_str(help_text) if help_text else None
         description = description if swagger_object_type != openapi.Items else None  # Items has no description either
 
-        def SwaggerType(existing_object=None, **instance_kwargs):
+        def SwaggerType(existing_object=None, use_field_title=True, **instance_kwargs):
             if 'required' not in instance_kwargs and swagger_object_type == openapi.Parameter:
                 instance_kwargs['required'] = field.required
 
@@ -285,7 +285,7 @@ class FieldInspector(BaseInspector):
                 if default not in (None, serializers.empty):
                     instance_kwargs['default'] = default
 
-            if instance_kwargs.get('type', None) != openapi.TYPE_ARRAY:
+            if use_field_title and instance_kwargs.get('type', None) != openapi.TYPE_ARRAY:
                 instance_kwargs.setdefault('title', title)
             if description is not None:
                 instance_kwargs.setdefault('description', description)

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -115,15 +115,13 @@ class InlineSerializerInspector(SerializerInspector):
                         required.append(property_name)
 
                 result = SwaggerType(
+                    # the title is derived from the field name and is better to
+                    # be omitted from models
+                    use_field_title=False,
                     type=openapi.TYPE_OBJECT,
                     properties=properties,
                     required=required or None,
                 )
-                if not ref_name and 'title' in result:
-                    # on an inline model, the title is derived from the field name
-                    # but is visno coverually displayed like the model name, which is confusing
-                    # it is better to just remove title from inline models
-                    del result.title
 
                 setattr(result, '_NP_serializer', get_serializer_class(serializer))
                 return result

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -1078,7 +1078,6 @@ definitions:
         readOnly: true
         format: uri
   Identity:
-    title: Identity
     type: object
     properties:
       id:
@@ -1370,7 +1369,6 @@ definitions:
         title: child
         todo: null
   OtherStuff:
-    title: Other stuff
     description: the decorator should determine the serializer class for this
     required:
       - foo
@@ -1381,7 +1379,6 @@ definitions:
         type: string
         minLength: 1
   MethodFieldExample:
-    title: Hint example
     type: object
     properties:
       hinted_bool:


### PR DESCRIPTION
Along with #566 this PR allows use by tools such as https://github.com/Yelp/bravado/ which uses the title for the "model" name. Although their choice is slightly debatable, the titles should not be defined by the first serializer they are used by (What currently will happen). This change removes the titles if they are based on the field name and leaves the possibility they might be added in some other way in the future.