### PR TITLE
Properly handle subclasses of SerializerMethodField

### DIFF
--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -570,7 +570,7 @@ class SerializerMethodFieldInspector(FieldInspector):
         if not isinstance(field, serializers.SerializerMethodField):
             return NotHandled
 
-        method = getattr(field.parent, field.method_name)
+        method = getattr(field.parent, field.method_name, None)
         if method is None:
             return NotHandled
 


### PR DESCRIPTION
I can add a test if needed, but this is a fairly simple fix. There's a check for None after this, so this was clearly the intended behavior.

In particular, I think this shows up if you subclass SerializerMethodField and don't use method_name.