### PR TITLE
Update Redoc to 2.0.0-rc36

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "drf-yasg",
   "dependencies": {
-    "redoc": "^2.0.0-rc.14",
+    "redoc": "^2.0.0-rc.36",
     "swagger-ui-dist": "^3.23.11"
   },
   "repository": {


### PR DESCRIPTION
Redoc has since made some bugfixes that would be useful (i.e. https://github.com/Redocly/redoc/issues/1177), so upgrading the Redoc version