### PR TITLE
Documentation: Include openapi Import Example

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,18 @@
 Changelog
 #########
 
+
+**********
+**1.17.1**
+**********
+
+*Release date: Feb 17, 2020*
+
+- **FIXED:** fixed compatibility issue with CurrentUserDefault in Django Rest Framework 3.11
+- **FIXED:** respect `USERNAME_FIELD` in `generate_swagger` command (:pr:`486`)
+
+**Support was dropped for Python 3.5, Django 2.0, Django 2.1, DRF 3.7**
+
 **********
 **1.17.0**
 **********

--- a/docs/custom_spec.rst
+++ b/docs/custom_spec.rst
@@ -62,7 +62,7 @@ Where you can use the :func:`@swagger_auto_schema <.swagger_auto_schema>` decora
 
    .. code-block:: python
 
-      from def_yasg import openapi
+      from drf_yasg import openapi
 
       test_param = openapi.Parameter('test', openapi.IN_QUERY, description="test manual param", type=openapi.TYPE_BOOLEAN)
       user_response = openapi.Response('response description', UserSerializer)


### PR DESCRIPTION
Developers new to drf-yasg will benefit from seeing an example of how to import openapi.