### PR TITLE
Drop all compat support to Django < 2.1 urls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ Generate **real** Swagger/OpenAPI 2.0 specifications from a Django Rest Framewor
 
 Compatible with
 
-- **Django Rest Framework**: 3.8, 3.9, 3.10, 3.11
-- **Django**: 1.11, 2.2, 3.0
+- **Django Rest Framework**: 3.8, 3.9, 3.10, 3.11, 3.12
+- **Django**: 2.2, 3.0
 - **Python**: 2.7, 3.6, 3.7, 3.8
 
 Only the latest patch version of each ``major.minor`` series of Python, Django and Django REST Framework is supported.

--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -6,9 +6,9 @@ from collections import OrderedDict, defaultdict
 import rest_framework
 import uritemplate
 from coreapi.compat import urlparse
+from django.urls import URLPattern, URLResolver
 from packaging.version import Version
 from rest_framework import versioning
-from rest_framework.compat import URLPattern, URLResolver, get_original_route
 from rest_framework.schemas.generators import EndpointEnumerator as _EndpointEnumerator
 from rest_framework.schemas.generators import endpoint_ordering, get_pk_name
 from rest_framework.settings import api_settings
@@ -93,7 +93,7 @@ class EndpointEnumerator(_EndpointEnumerator):
             ignored_endpoints = set()
 
         for pattern in patterns:
-            path_regex = prefix + get_original_route(pattern)
+            path_regex = prefix + str(pattern.pattern)
             if isinstance(pattern, URLPattern):
                 try:
                     path = self.get_path_from_regex(path_regex)

--- a/testproj/snippets/serializers.py
+++ b/testproj/snippets/serializers.py
@@ -2,15 +2,12 @@ from decimal import Decimal
 
 import rest_framework
 from django.contrib.auth import get_user_model
+from django.core.validators import MaxLengthValidator, MinValueValidator
 from packaging.version import Version
 from rest_framework import serializers
 
 from snippets.models import LANGUAGE_CHOICES, STYLE_CHOICES, Snippet, SnippetViewer
 
-if Version(rest_framework.__version__) < Version('3.10'):
-    from rest_framework.compat import MaxLengthValidator, MinValueValidator
-else:
-    from django.core.validators import MaxLengthValidator, MinValueValidator
 
 
 class LanguageSerializer(serializers.Serializer):

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ isolated_build_env = .package
 envlist =
     py36-django22-drf{38,39},
     py37-django22-drf{38,39,310,311,312},
-    py38-django{22,3}-drf{310,311,312},
+    py38-django{22,30}-drf{310,311,312},
     djmaster, lint, docs
 skip_missing_interpreters = true
 
@@ -20,8 +20,8 @@ deps =
     django22: Django>=2.2,<2.3
     django22: django-oauth-toolkit>=1.2.0
 
-    django3: Django>=2.2,<2.3
-    django3: django-oauth-toolkit>=1.2.0
+    django30: Django>=3.0,<3.1
+    django30: django-oauth-toolkit>=1.2.0
 
     drf38: djangorestframework>=3.8,<3.9
     drf39: djangorestframework>=3.9,<3.10

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ isolated_build_env = .package
 
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py36-django{111,22}-drf{38,39},
-    py37-django22-drf{38,39,310,311},
-    py38-django{22,3}-drf{310,311},
+    py36-django22-drf{38,39},
+    py37-django22-drf{38,39,310,311,312},
+    py38-django{22,3}-drf{310,311,312},
     djmaster, lint, docs
 skip_missing_interpreters = true
 
@@ -17,12 +17,6 @@ deps =
 
 [testenv]
 deps =
-    django111: Django>=1.11,<2.0
-    django111: django-oauth-toolkit>=1.1.0,<1.2.0
-
-    django21: Django>=2.1,<2.2
-    django21: django-oauth-toolkit>=1.2.0
-
     django22: Django>=2.2,<2.3
     django22: django-oauth-toolkit>=1.2.0
 
@@ -33,6 +27,7 @@ deps =
     drf39: djangorestframework>=3.9,<3.10
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
+    drf312: djangorestframework>=3.12.0
 
     typing: typing>=3.6.6
 


### PR DESCRIPTION
Dropping support for  Django < [2.1](https://www.djangoproject.com/download/#supported-versions)
And make compatible to `django-rest-framework 3.12.0`