### PR TITLE
Updated readme (added staticfiles in installed apps as a dependency)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,7 @@ In ``settings.py``:
 
    INSTALLED_APPS = [
       ...
+      'django.contrib.staticfiles',  # required for serving swagger ui's css/js files
       'drf_yasg',
       ...
    ]


### PR DESCRIPTION
added `django.contrib.staticfiles` in installed apps as a dependency. Required for serving swagger ui's css/js files