### PR TITLE
Default to "/accounts/logout/" rather than settings.LOGOUT_URL

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -169,7 +169,7 @@ LOGOUT_URL
 
 URL for the Django Logout action when using `USE_SESSION_AUTH`_.
 
-**Default**: :python:`django.conf.settings.LOGOUT_URL`
+**Default**: :python:`'/accounts/logout/'`
 
 .. _security-definitions-settings:
 

--- a/src/drf_yasg/app_settings.py
+++ b/src/drf_yasg/app_settings.py
@@ -40,7 +40,7 @@ SWAGGER_DEFAULTS = {
     },
     'SECURITY_REQUIREMENTS': None,
     'LOGIN_URL': getattr(settings, 'LOGIN_URL', None),
-    'LOGOUT_URL': getattr(settings, 'LOGOUT_URL', None),
+    'LOGOUT_URL': '/accounts/logout/',
     'SPEC_URL': None,
     'VALIDATOR_URL': '',
     'PERSIST_AUTH': False,


### PR DESCRIPTION
settings.LOGOUT_URL hasn't been included in Django since Django 1.10,
and hasn't functioned since pre-1.0.

The default of "/accounts/logout/" corresponds to most examples in the
documentation, and is more likely to work out of the box than the
present default of `None`.

See https://github.com/django/django/commit/59f861fcb49a43acfbf2f75e683a7cb971600f52