### PR TITLE
Remove direct usages of coreapi dependency

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
+coreapi>=2.3.3
 coreschema>=0.0.4
 ruamel.yaml>=0.15.34
 inflection>=0.3.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,3 @@
-coreapi>=2.3.3
 coreschema>=0.0.4
 ruamel.yaml>=0.15.34
 inflection>=0.3.1

--- a/src/drf_yasg/codecs.py
+++ b/src/drf_yasg/codecs.py
@@ -3,7 +3,7 @@ import json
 import logging
 from collections import OrderedDict
 
-from coreapi.compat import force_bytes
+from django.utils.encoding import force_bytes
 from ruamel import yaml
 
 from . import openapi

--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -1,8 +1,8 @@
 import copy
 import logging
 import re
-from collections import OrderedDict, defaultdict
 import urllib.parse as urlparse
+from collections import OrderedDict, defaultdict
 
 import uritemplate
 from django.urls import URLPattern, URLResolver

--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -2,9 +2,9 @@ import copy
 import logging
 import re
 from collections import OrderedDict, defaultdict
+import urllib.parse as urlparse
 
 import uritemplate
-from coreapi.compat import urlparse
 from django.urls import URLPattern, URLResolver
 from rest_framework import versioning
 from rest_framework.schemas import SchemaGenerator

--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -1,8 +1,8 @@
 import collections
 import logging
 import re
-from collections import OrderedDict
 import urllib.parse as urlparse
+from collections import OrderedDict
 
 from django.urls import get_script_prefix
 from django.utils.functional import Promise

--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -2,8 +2,8 @@ import collections
 import logging
 import re
 from collections import OrderedDict
+import urllib.parse as urlparse
 
-from coreapi.compat import urlparse
 from django.urls import get_script_prefix
 from django.utils.functional import Promise
 from inflection import camelize


### PR DESCRIPTION
First part of #389.  Remove direct usages of `coreapi` compatibility shims.

`coreschema` is left for another PR.

This PR does not fully remove `coreapi` dependency, because the `OpenAPISchemaGenerator` depends on `rest_framework.schemas.SchemaGenerator`, which still requires `coreapi`.

Note that I believe `rest_framework.schemas.SchemaGenerator` will be removed in DRF 3.14, so we need to eventually address this.