### PR TITLE
Use a list, not a tuple, for permission_classes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,7 @@ In ``urls.py``:
          license=openapi.License(name="BSD License"),
       ),
       public=True,
-      permission_classes=(permissions.AllowAny,),
+      permission_classes=[permissions.AllowAny],
    )
 
    urlpatterns = [

--- a/src/drf_yasg/views.py
+++ b/src/drf_yasg/views.py
@@ -59,7 +59,7 @@ def get_schema_view(info=None, url=None, patterns=None, urlconf=None, public=Fal
     :param list validators: a list of validator names to apply; the only allowed value is ``ssv``, for now
     :param type generator_class: schema generator class to use; should be a subclass of :class:`.OpenAPISchemaGenerator`
     :param tuple authentication_classes: authentication classes for the schema view itself
-    :param tuple permission_classes: permission classes for the schema view itself
+    :param list permission_classes: permission classes for the schema view itself
     :return: SchemaView class
     :rtype: type[drf_yasg.views.SchemaView]
     """

--- a/testproj/testproj/settings/base.py
+++ b/testproj/testproj/settings/base.py
@@ -88,9 +88,9 @@ AUTH_PASSWORD_VALIDATORS = [
 
 # Django Rest Framework
 REST_FRAMEWORK = {
-    'DEFAULT_PERMISSION_CLASSES': (
+    'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
-    )
+    ]
 }
 
 OAUTH2_CLIENT_ID = '12ee6bgxtpSEgP8TioWcHSXOiDBOUrVav4mRbVEs'

--- a/testproj/testproj/urls.py
+++ b/testproj/testproj/urls.py
@@ -26,7 +26,7 @@ You can log in using the pre-existing `admin` user with password `passwordadmin`
 SchemaView = get_schema_view(
     validators=['ssv', 'flex'],
     public=True,
-    permission_classes=(permissions.AllowAny,),
+    permission_classes=[permissions.AllowAny],
 )
 
 

--- a/tests/urlconfs/non_public_urls.py
+++ b/tests/urlconfs/non_public_urls.py
@@ -8,7 +8,7 @@ from drf_yasg.views import get_schema_view
 view = get_schema_view(
     openapi.Info('bla', 'ble'),
     public=False,
-    permission_classes=(permissions.AllowAny,)
+    permission_classes=[permissions.AllowAny]
 )
 view = view.without_ui(cache_timeout=None)
 


### PR DESCRIPTION
DRF expects permission classes to be in a list:
https://www.django-rest-framework.org/api-guide/permissions

Semantically, this should be a list, as the number of elements is arbitrary.