### PR TITLE
Do not use a leading dot to specify SwaggerRenderer formats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ In ``urls.py``:
    )
 
    urlpatterns = [
-      url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+      url(r'^swagger\.(?P<format>json|yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
       url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
       url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
       ...

--- a/src/drf_yasg/renderers.py
+++ b/src/drf_yasg/renderers.py
@@ -45,14 +45,14 @@ class OpenAPIRenderer(_SpecRenderer):
 class SwaggerJSONRenderer(_SpecRenderer):
     """Renders the schema as a JSON document with the generic ``application/json`` mime type."""
     media_type = 'application/json'
-    format = '.json'
+    format = 'json'
     codec_class = OpenAPICodecJson
 
 
 class SwaggerYAMLRenderer(_SpecRenderer):
     """Renders the schema as a YAML document."""
     media_type = 'application/yaml'
-    format = '.yaml'
+    format = 'yaml'
     codec_class = OpenAPICodecYaml
 
 

--- a/testproj/testproj/urls.py
+++ b/testproj/testproj/urls.py
@@ -54,13 +54,13 @@ required_urlpatterns = [
 ]
 
 urlpatterns = [
-    re_path(r'^swagger(?P<format>.json|.yaml)$', SchemaView.without_ui(cache_timeout=0),
+    re_path(r'^swagger\.(?P<format>json|yaml)$', SchemaView.without_ui(cache_timeout=0),
             name='schema-json'),
     path('swagger/', SchemaView.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path('redoc/', SchemaView.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
     path('redoc-old/', SchemaView.with_ui('redoc-old', cache_timeout=0), name='schema-redoc-old'),
 
-    re_path(r'^cached/swagger(?P<format>.json|.yaml)$', SchemaView.without_ui(cache_timeout=None),
+    re_path(r'^cached/swagger\.(?P<format>json|yaml)$', SchemaView.without_ui(cache_timeout=None),
             name='cschema-json'),
     path('cached/swagger/', SchemaView.with_ui('swagger', cache_timeout=None), name='cschema-swagger-ui'),
     path('cached/redoc/', SchemaView.with_ui('redoc', cache_timeout=None), name='cschema-redoc'),

--- a/tests/urlconfs/ns_versioning.py
+++ b/tests/urlconfs/ns_versioning.py
@@ -13,7 +13,7 @@ class VersionedSchemaView(SchemaView):
 
 
 schema_patterns = [
-    re_path(r'swagger(?P<format>.json|.yaml)$', VersionedSchemaView.without_ui(), name='ns-schema')
+    re_path(r'swagger\.(?P<format>json|yaml)$', VersionedSchemaView.without_ui(), name='ns-schema')
 ]
 
 

--- a/tests/urlconfs/url_versioning.py
+++ b/tests/urlconfs/url_versioning.py
@@ -44,6 +44,6 @@ class VersionedSchemaView(SchemaView):
 
 urlpatterns = required_urlpatterns + [
     re_path(VERSION_PREFIX_URL + r"snippets/$", SnippetList.as_view()),
-    re_path(VERSION_PREFIX_URL + r'swagger(?P<format>.json|.yaml)$', VersionedSchemaView.without_ui(),
+    re_path(VERSION_PREFIX_URL + r'swagger\.(?P<format>json|yaml)$', VersionedSchemaView.without_ui(),
             name='vschema-json'),
 ]


### PR DESCRIPTION
DRF expects that custom Renderers use a simple string for the `format`: https://www.django-rest-framework.org/api-guide/renderers/#custom-renderers

This is also required to support content negotiation via DRF's native mechanisms, particularly `format_suffix_patterns`: https://www.django-rest-framework.org/api-guide/format-suffixes/

Note that all the other DRF-YASG renderers (including `OpenAPIRenderer` and `SwaggerUIRenderer`) already do the correct thing. This change just updates the `SwaggerJSONRenderer` and `SwaggerYAMLRenderer` to be consistent and correct.