### PR TITLE
Use a list, not a tuple, for authentication_classes

### DIFF
--- a/src/drf_yasg/views.py
+++ b/src/drf_yasg/views.py
@@ -58,7 +58,7 @@ def get_schema_view(info=None, url=None, patterns=None, urlconf=None, public=Fal
     :param bool public: if False, includes only the endpoints that are accesible by the user viewing the schema
     :param list validators: a list of validator names to apply; the only allowed value is ``ssv``, for now
     :param type generator_class: schema generator class to use; should be a subclass of :class:`.OpenAPISchemaGenerator`
-    :param tuple authentication_classes: authentication classes for the schema view itself
+    :param list authentication_classes: authentication classes for the schema view itself
     :param tuple permission_classes: permission classes for the schema view itself
     :return: SchemaView class
     :rtype: type[drf_yasg.views.SchemaView]


### PR DESCRIPTION
DRF expects authentication classes to be in a list: https://www.django-rest-framework.org/api-guide/authentication/

Semantically, this should be a list, as the number of elements is arbitrary.