### PR TITLE
Change url() to re_path()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,9 +152,9 @@ In ``urls.py``:
    )
 
    urlpatterns = [
-      url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
-      url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-      url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+      re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+      re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+      re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
       ...
    ]
 


### PR DESCRIPTION
`url()` function is deprecated since Django 3.1.

Since drf-yasg is compatible with Django 3.1, I think it would be better to replace `url()` with `re_path()`.