### PR TITLE
Allow specifying response as a reference

### DIFF
--- a/src/drf_yasg/inspectors/view.py
+++ b/src/drf_yasg/inspectors/view.py
@@ -262,6 +262,8 @@ class SwaggerAutoSchema(ViewInspector):
                     description='',
                     schema=serializer,
                 )
+            elif isinstance(serializer, openapi._Ref):
+                response = serializer
             else:
                 serializer = force_serializer_instance(serializer)
                 response = openapi.Response(


### PR DESCRIPTION
We're trying to support a usecase of defining `responses` in one place and then referencing them in the schema. This is useful for specifying generic errors (e.g. 500 is always "Server Error"). Examples from resulting OpenAPI YAML fragments:

```
responses:
  NotFound:
    description: "Requested object not found."
  ServerError:
    description: "Internal server error."

... 
paths:
  /example_resource/:
    get:
      # ... omitted for brevity
      responses:
        404:
          $ref: "#/responses/NotFound"
        500:
          $ref: "#/responses/ServerError"
```

`drf_yasg` custom code would look like this:

```
class ResponseRef(_Ref):
    def __init__(self, schema_name):
        super().__init__(None, schema_name, 'responses', None, ignore_unresolved=True)

@method_decorator(name='list', decorator=swagger_auto_schema(
    responses={
        404: ResponseRef('NotFound'),
        500: ResponseRef('ServerError'),
    },
))
class SomeViewSet(ListModelMixin, BaseApiViewSet):
    # ...
```

