### PR TITLE
fix when multiple actions have the same url_path

### DIFF
--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -94,13 +94,14 @@ class EndpointEnumerator(_EndpointEnumerator):
                     if self.should_include_endpoint(path, callback, app_name or '', namespace or '', url_name):
                         path = self.replace_version(path, callback)
 
-                        # avoid adding endpoints that have already been seen,
-                        # as Django resolves urls in top-down order
-                        if path in ignored_endpoints:
-                            continue
-                        ignored_endpoints.add(path)
-
                         for method in self.get_allowed_methods(callback):
+                            # avoid adding endpoints that have already been seen,
+                            # as Django resolves urls in top-down order
+                            ignore_endpoint = (path, method)
+                            if ignore_endpoint in ignored_endpoints:
+                                continue
+                            ignored_endpoints.add(ignore_endpoint)
+
                             endpoint = (path, method, callback)
                             api_endpoints.append(endpoint)
                 except Exception:  # pragma: no cover


### PR DESCRIPTION
this pull request fix case when multiple actions having the same url_path, while not using `action.mapping`

```python
@action(detail=False, methods=['get'], url_path='test')
def action_get(self, request):
    pass

@action(detail=False, methods=['post'], url_path='test')
def action_post(self, request):
    pass
```
In this case, the swagger will only show `GET /test`, not including `POST /test`