### PR TITLE
Declare Django 3.2 support in README, classifiers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Generate **real** Swagger/OpenAPI 2.0 specifications from a Django Rest Framewor
 Compatible with
 
 - **Django Rest Framework**: 3.10, 3.11, 3.12
-- **Django**: 2.2, 3.0, 3.1
+- **Django**: 2.2, 3.0, 3.1, 3.2
 - **Python**: 3.6, 3.7, 3.8, 3.9
 
 Only the latest patch version of each ``major.minor`` series of Python, Django and Django REST Framework is supported.


### PR DESCRIPTION
This commit will make sure that `Django :: 3.2` will show up in the
classifiers list on PyPI: https://pypi.org/project/drf-yasg/

<img width="158" alt="image" src="https://user-images.githubusercontent.com/901169/182651562-66e108f7-0650-40b1-99ea-05d905f4abfb.png">


(The magic happens because we parse the README to get supported Django):
https://github.com/DavidCain/drf-yasg/blob/ee29412d3cdb311/setup.py#L36

3.2 support should already exist
================================
A closed pull request, https://github.com/axnsan12/drf-yasg/pull/735,
noted support for Django 3.2 in both `tox.ini`, and the README.

That PR was closed in favor of https://github.com/axnsan12/drf-yasg/pull/741, which edited `tox.ini` and switched to GitHub Actions.

https://github.com/axnsan12/drf-yasg/pull/735#issuecomment-924298555

This project has been testing on Django 3.2 for a long time (about a
year). I think we can declare it supported it the README!