### PR TITLE
Fix documentation generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ version = '.'.join(release.split('.')[:3])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal = 1
 
 [metadata]
-license_file = LICENSE.rst
+license_files = LICENSE.rst

--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -236,7 +236,7 @@ class Swagger(SwaggerDict):
                  security_definitions=None, security=None, paths=None, definitions=None, **extra):
         """Root Swagger object.
 
-        :param .Info info: info object
+        :param Info info: info object
         :param str _url: URL used for setting the API host and scheme
         :param str _prefix: api path prefix to use in setting basePath; this will be appended to the wsgi
             SCRIPT_NAME prefix or Django's FORCE_SCRIPT_NAME if applicable
@@ -391,7 +391,7 @@ class Items(SwaggerDict):
         :param str format: value format, see OpenAPI spec
         :param list enum: restrict possible values
         :param str pattern: pattern if type is ``string``
-        :param .Items items: only valid if `type` is ``array``
+        :param Items items: only valid if `type` is ``array``
         """
         super(Items, self).__init__(**extra)
         assert type is not None, "type is required!"
@@ -420,7 +420,7 @@ class Parameter(SwaggerDict):
         :param str format: value format, see OpenAPI spec
         :param list enum: restrict possible values
         :param str pattern: pattern if type is ``string``
-        :param .Items items: only valid if `type` is ``array``
+        :param Items items: only valid if `type` is ``array``
         :param default: default value if the parameter is not provided; must conform to parameter type
         """
         super(Parameter, self).__init__(**extra)
@@ -512,10 +512,10 @@ class _Ref(SwaggerDict):
         """Base class for all reference types. A reference object has only one property, ``$ref``, which must be a JSON
         reference to a valid object in the specification, e.g. ``#/definitions/Article`` to refer to an article model.
 
-        :param .ReferenceResolver resolver: component resolver which must contain the referneced object
+        :param ReferenceResolver resolver: component resolver which must contain the referneced object
         :param str name: referenced object name, e.g. "Article"
         :param str scope: reference scope, e.g. "definitions"
-        :param type[.SwaggerDict] expected_type: the expected type that will be asserted on the object found in resolver
+        :param type[SwaggerDict] expected_type: the expected type that will be asserted on the object found in resolver
         :param bool ignore_unresolved: do not throw if the referenced object does not exist
         """
         super(_Ref, self).__init__()
@@ -530,7 +530,7 @@ class _Ref(SwaggerDict):
     def resolve(self, resolver):
         """Get the object targeted by this reference from the given component resolver.
 
-        :param .ReferenceResolver resolver: component resolver which must contain the referneced object
+        :param ReferenceResolver resolver: component resolver which must contain the referneced object
         :returns: the target object
         """
         ref_match = self.ref_name_re.match(self.ref)
@@ -549,7 +549,7 @@ class SchemaRef(_Ref):
     def __init__(self, resolver, schema_name, ignore_unresolved=False):
         """Adds a reference to a named Schema defined in the ``#/definitions/`` object.
 
-        :param .ReferenceResolver resolver: component resolver which must contain the definition
+        :param ReferenceResolver resolver: component resolver which must contain the definition
         :param str schema_name: schema name
         :param bool ignore_unresolved: do not throw if the referenced object does not exist
         """
@@ -647,7 +647,7 @@ class ReferenceResolver(object):
 
         :param str scope: target scope, must be in this resolver's `scopes`
         :return: the bound resolver
-        :rtype: .ReferenceResolver
+        :rtype: ReferenceResolver
         """
         assert scope in self.scopes, "unknown scope %s" % scope
         ret = ReferenceResolver(force_init=True)

--- a/src/drf_yasg/views.py
+++ b/src/drf_yasg/views.py
@@ -51,7 +51,8 @@ def get_schema_view(info=None, url=None, patterns=None, urlconf=None, public=Fal
                     generator_class=None, authentication_classes=None, permission_classes=None):
     """Create a SchemaView class with default renderers and generators.
 
-    :param .Info info: information about the API; if omitted, defaults to :ref:`DEFAULT_INFO <default-swagger-settings>`
+    :param drf_yasg.openapi.Info info: information about the API; if omitted,
+        defaults to :ref:`DEFAULT_INFO <default-swagger-settings>`
     :param str url: same as :class:`.OpenAPISchemaGenerator`
     :param patterns: same as :class:`.OpenAPISchemaGenerator`
     :param urlconf: same as :class:`.OpenAPISchemaGenerator`

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ isolated_build_env = .package
 envlist =
     py{36,37,38,39}-django{22,30}-drf{310,311,312},
     py{36,37,38,39}-django{31,32}-drf{311,312},
-    py38-{lint, docs},
+    lint,
+    docs,
     py39-djmaster
 
 skip_missing_interpreters = true


### PR DESCRIPTION
This allow `tox -e docs` to run without warnings or errors. This was mostly fixing class references in docstrings. A few other changes:

* Switch `license_file` to `license_files` in setup.cfg. This was added to setuptools in v42.0.0 (Nov 2019), and `license_file` was deprecated in v57.0.0 (May 2021).
* Fix the `envlist` for `tox`. Running `tox -e py38-lint` would run pytest, not flake8, and `tox -e py38-docs` would not build docs.