### PR TITLE
Fix #810 Remove NullBooleanField for serializers

### DIFF
--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -403,7 +403,6 @@ serializer_field_to_basic_type = [
     (serializers.RegexField, (openapi.TYPE_STRING, None)),
     (serializers.CharField, (openapi.TYPE_STRING, None)),
     (serializers.BooleanField, (openapi.TYPE_BOOLEAN, None)),
-    (serializers.NullBooleanField, (openapi.TYPE_BOOLEAN, None)),
     (serializers.IntegerField, (openapi.TYPE_INTEGER, None)),
     (serializers.FloatField, (openapi.TYPE_NUMBER, None)),
     (serializers.DecimalField, (decimal_field_type, openapi.FORMAT_DECIMAL)),


### PR DESCRIPTION
This fixes #810 for DRF versions >= 3.14

However this is a breaking change for people using NullBooleanField in previous versions of Django Rest Framework. I don't know what is your deprecation policy for cases like these. I am happy to further contribute if you do have one.