### PR TITLE
Fix compatibility with django-rest-framework 3.14.0 having depreciated NullBooleanField

### DIFF
--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -42,7 +42,7 @@ class InlineSerializerInspector(SerializerInspector):
         is called only when the serializer is converted into a list of parameters for use in a form data request.
 
         :param serializer: serializer instance
-        :param list[openapi.Parameter] parameters: genereated parameters
+        :param list[openapi.Parameter] parameters: generated parameters
         :return: modified parameters
         :rtype: list[openapi.Parameter]
         """
@@ -181,7 +181,7 @@ def get_queryset_from_view(view, serializer=None):
     """Try to get the queryset of the given view
 
     :param view: the view instance or class
-    :param serializer: if given, will check that the view's get_serializer_class return matches this serialzier
+    :param serializer: if given, will check that the view's get_serializer_class return matches this serializer
     :return: queryset or ``None``
     """
     try:
@@ -406,7 +406,7 @@ serializer_field_to_basic_type = [
     (serializers.UUIDField, (openapi.TYPE_STRING, openapi.FORMAT_UUID)),
     (serializers.RegexField, (openapi.TYPE_STRING, None)),
     (serializers.CharField, (openapi.TYPE_STRING, None)),
-    (serializers.NullBooleanField, (openapi.TYPE_BOOLEAN, None)),
+    (serializers.BooleanField, (openapi.TYPE_BOOLEAN, None)),
     (serializers.IntegerField, (openapi.TYPE_INTEGER, None)),
     (serializers.FloatField, (openapi.TYPE_NUMBER, None)),
     (serializers.DecimalField, (decimal_field_type, openapi.FORMAT_DECIMAL)),
@@ -422,7 +422,7 @@ if version.parse(drf_version) < version.parse("3.14.0"):
     )
 
     serializer_field_to_basic_type.append(
-        (serializers.BooleanField, (openapi.TYPE_BOOLEAN, None)),
+        (serializers.NullBooleanField, (openapi.TYPE_BOOLEAN, None)),
     )
 
 basic_type_info = serializer_field_to_basic_type + model_field_to_basic_type

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -4,6 +4,8 @@ import logging
 import operator
 import typing
 import uuid
+import pkg_resources
+from packaging import version
 from collections import OrderedDict
 from decimal import Decimal
 from inspect import signature as inspect_signature
@@ -19,6 +21,9 @@ from ..utils import (
     decimal_as_float, field_value_to_representation, filter_none, get_serializer_class, get_serializer_ref_name
 )
 from .base import FieldInspector, NotHandled, SerializerInspector, call_view_method
+
+
+drf_version = pkg_resources.get_distribution("djangorestframework").version
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +42,7 @@ class InlineSerializerInspector(SerializerInspector):
         is called only when the serializer is converted into a list of parameters for use in a form data request.
 
         :param serializer: serializer instance
-        :param list[openapi.Parameter] parameters: generated parameters
+        :param list[openapi.Parameter] parameters: genereated parameters
         :return: modified parameters
         :rtype: list[openapi.Parameter]
         """
@@ -176,7 +181,7 @@ def get_queryset_from_view(view, serializer=None):
     """Try to get the queryset of the given view
 
     :param view: the view instance or class
-    :param serializer: if given, will check that the view's get_serializer_class return matches this serializer
+    :param serializer: if given, will check that the view's get_serializer_class return matches this serialzier
     :return: queryset or ``None``
     """
     try:
@@ -376,7 +381,6 @@ model_field_to_basic_type = [
     (models.AutoField, (openapi.TYPE_INTEGER, None)),
     (models.BinaryField, (openapi.TYPE_STRING, openapi.FORMAT_BINARY)),
     (models.BooleanField, (openapi.TYPE_BOOLEAN, None)),
-    (models.NullBooleanField, (openapi.TYPE_BOOLEAN, None)),
     (models.DateTimeField, (openapi.TYPE_STRING, openapi.FORMAT_DATETIME)),
     (models.DateField, (openapi.TYPE_STRING, openapi.FORMAT_DATE)),
     (models.DecimalField, (decimal_field_type, openapi.FORMAT_DECIMAL)),
@@ -390,7 +394,7 @@ model_field_to_basic_type = [
     (models.TimeField, (openapi.TYPE_STRING, None)),
     (models.UUIDField, (openapi.TYPE_STRING, openapi.FORMAT_UUID)),
     (models.CharField, (openapi.TYPE_STRING, None)),
-]
+]    
 
 ip_format = {'ipv4': openapi.FORMAT_IPV4, 'ipv6': openapi.FORMAT_IPV6}
 
@@ -402,7 +406,6 @@ serializer_field_to_basic_type = [
     (serializers.UUIDField, (openapi.TYPE_STRING, openapi.FORMAT_UUID)),
     (serializers.RegexField, (openapi.TYPE_STRING, None)),
     (serializers.CharField, (openapi.TYPE_STRING, None)),
-    (serializers.BooleanField, (openapi.TYPE_BOOLEAN, None)),
     (serializers.NullBooleanField, (openapi.TYPE_BOOLEAN, None)),
     (serializers.IntegerField, (openapi.TYPE_INTEGER, None)),
     (serializers.FloatField, (openapi.TYPE_NUMBER, None)),
@@ -412,6 +415,15 @@ serializer_field_to_basic_type = [
     (serializers.DateTimeField, (openapi.TYPE_STRING, openapi.FORMAT_DATETIME)),
     (serializers.ModelField, (openapi.TYPE_STRING, None)),
 ]
+
+if version.parse(drf_version) < version.parse("3.14.0"):
+    model_field_to_basic_type.append(
+        (models.NullBooleanField, (openapi.TYPE_BOOLEAN, None))
+    )
+
+    serializer_field_to_basic_type.append(
+        (serializers.BooleanField, (openapi.TYPE_BOOLEAN, None)),
+    )
 
 basic_type_info = serializer_field_to_basic_type + model_field_to_basic_type
 
@@ -840,3 +852,4 @@ else:
                 return ref
 
             return NotHandled
+


### PR DESCRIPTION
As pointed out in #810, django-rest-framework 3.14.0 has depreciated its NullBooleanField. 

For the sake of backwards compatibility we can drop the NullBooleanField types when the installed version of django-rest-framework exceeds 3.14.0.
