### PR TITLE
Update README to use path instead of re_path in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,9 +152,9 @@ In ``urls.py``:
    )
 
    urlpatterns = [
-      re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
-      re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-      re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+      path('swagger<format>/', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+      path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+      path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
       ...
    ]
 


### PR DESCRIPTION
`path` is typically recommended and more readable over `re_path` wherever possible. The first route changes functionality slightly by losing the explicit capture group so we may want to leave that to still use `re_path`.