### PR TITLE
Adding Python 3.11 into the test matrix

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout the source code

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Compatible with
 
 - **Django Rest Framework**: 3.10, 3.11, 3.12, 3.13, 3.14
 - **Django**: 2.2, 3.0, 3.1, 3.2, 4.0, 4.1
-- **Python**: 3.6, 3.7, 3.8, 3.9, 3.10
+- **Python**: 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
 
 Only the latest patch version of each ``major.minor`` series of Python, Django and Django REST Framework is supported.
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     py{37,38,39}-django{22,30}-drf{310,311,312},
     py{37,38,39}-django{31,32}-drf{311,312},
     py{39,310}-django{40,41}-drf{313,314}
+    py{311}-django{41}-drf{313,314}
     py38-{lint, docs},
     py39-djmaster
 


### PR DESCRIPTION
I've added Python 3.11 into the test matrix and README.rst as I am using the package on Python 3.11 and have personally run it with both 3.11.1 and 3.11.2 as a followup to #771 .

I'll test Django 4.2-alpha at some-point as well as I'm pretty sure it will work which will go alongside #817 