### PR TITLE
Fix: Provide support for enums in codecs.

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout the source code

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Compatible with
 
 - **Django Rest Framework**: 3.10, 3.11, 3.12, 3.13, 3.14
 - **Django**: 2.2, 3.0, 3.1, 3.2, 4.0, 4.1
-- **Python**: 3.6, 3.7, 3.8, 3.9, 3.10
+- **Python**: 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
 
 Only the latest patch version of each ``major.minor`` series of Python, Django and Django REST Framework is supported.
 
@@ -362,7 +362,7 @@ provided out of the box - if you have ``djangorestframework-recursive`` installe
 drf-extra-fields
 =================
 
-Integration with `drf-extra-fields <https://github.com/Hipo/drf-extra-fields>`_ has a problem with Base64 fields. 
+Integration with `drf-extra-fields <https://github.com/Hipo/drf-extra-fields>`_ has a problem with Base64 fields.
 The drf-yasg will generate Base64 file or image fields as Readonly and not required. Here is a workaround code
 for display the Base64 fields correctly.
 
@@ -370,7 +370,7 @@ for display the Base64 fields correctly.
 
   class PDFBase64FileField(Base64FileField):
       ALLOWED_TYPES = ['pdf']
-  
+
       class Meta:
           swagger_schema_fields = {
               'type': 'string',
@@ -378,7 +378,7 @@ for display the Base64 fields correctly.
               'description': 'Content of the file base64 encoded',
               'read_only': False  # <-- FIX
           }
-  
+
       def get_file_extension(self, filename, decoded_file):
           try:
               PyPDF2.PdfFileReader(io.BytesIO(decoded_file))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ version = '.'.join(release.split('.')[:3])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,4 +1,4 @@
 # used by the 'lint' tox env for linting via flake8
-isort>=4.2
-flake8>=3.5.0
-flake8-isort>=2.3
+isort>=5.12
+flake8>=6.0.0
+flake8-isort>=6.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,7 @@ pytest-cov>=2.6.0
 pytest-xdist>=1.25.0
 pytest-django>=3.4.4
 datadiff==2.0.0
-psycopg2-binary==2.9.4
+psycopg2-binary==2.9.5
 django-fake-model==0.1.4
 
 -r testproj.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -1,2 +1,2 @@
 # requirements for building and running tox
-tox>=3.3.0
+tox>=3.3.0,<4

--- a/src/drf_yasg/app_settings.py
+++ b/src/drf_yasg/app_settings.py
@@ -92,7 +92,7 @@ IMPORT_STRINGS = [
 ]
 
 
-class AppSettings(object):
+class AppSettings:
     """
     Stolen from Django Rest Framework, removed caching for easier testing
     """

--- a/src/drf_yasg/codecs.py
+++ b/src/drf_yasg/codecs.py
@@ -41,7 +41,7 @@ VALIDATORS = {
 }
 
 
-class _OpenAPICodec(object):
+class _OpenAPICodec:
     media_type = None
 
     def __init__(self, validators):

--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -155,7 +155,7 @@ class EndpointEnumerator(_EndpointEnumerator):
         return clean_path
 
 
-class OpenAPISchemaGenerator(object):
+class OpenAPISchemaGenerator:
     """
     This class iterates over all registered API endpoints and returns an appropriate OpenAPI 2.0 compliant schema.
     Method implementations shamelessly stolen and adapted from rest-framework ``SchemaGenerator``.

--- a/src/drf_yasg/inspectors/base.py
+++ b/src/drf_yasg/inspectors/base.py
@@ -51,7 +51,7 @@ def call_view_method(view, method_name, fallback_attr=None, default=None):
     return default
 
 
-class BaseInspector(object):
+class BaseInspector:
     def __init__(self, view, path, method, components, request):
         """
         :param rest_framework.views.APIView view: the view associated with this endpoint

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -2,26 +2,25 @@ import datetime
 import inspect
 import logging
 import operator
-import typing
 import uuid
-import pkg_resources
-from packaging import version
 from collections import OrderedDict
 from decimal import Decimal
 from inspect import signature as inspect_signature
 
+import pkg_resources
+import typing
 from django.core import validators
 from django.db import models
+from packaging import version
 from rest_framework import serializers
 from rest_framework.settings import api_settings as rest_framework_settings
 
+from .base import call_view_method, FieldInspector, NotHandled, SerializerInspector
 from .. import openapi
 from ..errors import SwaggerGenerationError
 from ..utils import (
     decimal_as_float, field_value_to_representation, filter_none, get_serializer_class, get_serializer_ref_name
 )
-from .base import FieldInspector, NotHandled, SerializerInspector, call_view_method
-
 
 drf_version = pkg_resources.get_distribution("djangorestframework").version
 
@@ -394,7 +393,7 @@ model_field_to_basic_type = [
     (models.TimeField, (openapi.TYPE_STRING, None)),
     (models.UUIDField, (openapi.TYPE_STRING, openapi.FORMAT_UUID)),
     (models.CharField, (openapi.TYPE_STRING, None)),
-]    
+]
 
 ip_format = {'ipv4': openapi.FORMAT_IPV4, 'ipv6': openapi.FORMAT_IPV6}
 
@@ -852,4 +851,3 @@ else:
                 return ref
 
             return NotHandled
-

--- a/src/drf_yasg/middleware.py
+++ b/src/drf_yasg/middleware.py
@@ -4,7 +4,7 @@ from .codecs import _OpenAPICodec
 from .errors import SwaggerValidationError
 
 
-class SwaggerExceptionMiddleware(object):
+class SwaggerExceptionMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 

--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -1,6 +1,7 @@
 import collections
 import logging
 import re
+import enum
 import urllib.parse as urlparse
 from collections import OrderedDict
 
@@ -152,6 +153,8 @@ class SwaggerDict(OrderedDict):
             return force_real_str(obj)
         elif isinstance(obj, collections_abc.Iterable) and not isinstance(obj, collections_abc.Iterator):
             return type(obj)(SwaggerDict._as_odict(elem, memo) for elem in obj)
+        elif isinstance(obj, enum.Enum):
+            return obj.value
 
         return obj
 

--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -141,7 +141,7 @@ class SwaggerDict(OrderedDict):
             if not isinstance(obj, dict):
                 items = sorted(items)
             for attr, val in items:
-                result[attr] = SwaggerDict._as_odict(val, memo)
+                result[SwaggerDict._as_odict(attr, memo)] = SwaggerDict._as_odict(val, memo)
             return result
         elif isinstance(obj, str):
             return force_real_str(obj)

--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -233,7 +233,7 @@ class Swagger(SwaggerDict):
                  security_definitions=None, security=None, paths=None, definitions=None, **extra):
         """Root Swagger object.
 
-        :param .Info info: info object
+        :param Info info: info object
         :param str _url: URL used for setting the API host and scheme
         :param str _prefix: api path prefix to use in setting basePath; this will be appended to the wsgi
             SCRIPT_NAME prefix or Django's FORCE_SCRIPT_NAME if applicable
@@ -388,7 +388,7 @@ class Items(SwaggerDict):
         :param str format: value format, see OpenAPI spec
         :param list enum: restrict possible values
         :param str pattern: pattern if type is ``string``
-        :param .Items items: only valid if `type` is ``array``
+        :param Items items: only valid if `type` is ``array``
         """
         super(Items, self).__init__(**extra)
         assert type is not None, "type is required!"
@@ -417,7 +417,7 @@ class Parameter(SwaggerDict):
         :param str format: value format, see OpenAPI spec
         :param list enum: restrict possible values
         :param str pattern: pattern if type is ``string``
-        :param .Items items: only valid if `type` is ``array``
+        :param Items items: only valid if `type` is ``array``
         :param default: default value if the parameter is not provided; must conform to parameter type
         """
         super(Parameter, self).__init__(**extra)
@@ -509,10 +509,10 @@ class _Ref(SwaggerDict):
         """Base class for all reference types. A reference object has only one property, ``$ref``, which must be a JSON
         reference to a valid object in the specification, e.g. ``#/definitions/Article`` to refer to an article model.
 
-        :param .ReferenceResolver resolver: component resolver which must contain the referenced object
+        :param ReferenceResolver resolver: component resolver which must contain the referenced object
         :param str name: referenced object name, e.g. "Article"
         :param str scope: reference scope, e.g. "definitions"
-        :param type[.SwaggerDict] expected_type: the expected type that will be asserted on the object found in resolver
+        :param type[SwaggerDict] expected_type: the expected type that will be asserted on the object found in resolver
         :param bool ignore_unresolved: do not throw if the referenced object does not exist
         """
         super(_Ref, self).__init__()
@@ -527,7 +527,7 @@ class _Ref(SwaggerDict):
     def resolve(self, resolver):
         """Get the object targeted by this reference from the given component resolver.
 
-        :param .ReferenceResolver resolver: component resolver which must contain the referenced object
+        :param ReferenceResolver resolver: component resolver which must contain the referenced object
         :returns: the target object
         """
         ref_match = self.ref_name_re.match(self.ref)
@@ -546,7 +546,7 @@ class SchemaRef(_Ref):
     def __init__(self, resolver, schema_name, ignore_unresolved=False):
         """Adds a reference to a named Schema defined in the ``#/definitions/`` object.
 
-        :param .ReferenceResolver resolver: component resolver which must contain the definition
+        :param ReferenceResolver resolver: component resolver which must contain the definition
         :param str schema_name: schema name
         :param bool ignore_unresolved: do not throw if the referenced object does not exist
         """
@@ -644,7 +644,7 @@ class ReferenceResolver(object):
 
         :param str scope: target scope, must be in this resolver's `scopes`
         :return: the bound resolver
-        :rtype: .ReferenceResolver
+        :rtype: ReferenceResolver
         """
         assert scope in self.scopes, "unknown scope %s" % scope
         ret = ReferenceResolver(force_init=True)

--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -1,20 +1,14 @@
-import collections
+import enum
 import logging
 import re
-import enum
 import urllib.parse as urlparse
-from collections import OrderedDict
+from collections import OrderedDict, abc as collections_abc
 
 from django.urls import get_script_prefix
 from django.utils.functional import Promise
 from inflection import camelize
 
-from .utils import dict_has_ordered_keys, filter_none, force_real_str
-
-try:
-    from collections import abc as collections_abc
-except ImportError:
-    collections_abc = collections
+from .utils import filter_none, force_real_str
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +138,7 @@ class SwaggerDict(OrderedDict):
             result = OrderedDict()
             memo[id(obj)] = result
             items = obj.items()
-            if not dict_has_ordered_keys(obj):
+            if not isinstance(obj, dict):
                 items = sorted(items)
             for attr, val in items:
                 result[attr] = SwaggerDict._as_odict(val, memo)

--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -1,6 +1,5 @@
 import inspect
 import logging
-import sys
 import textwrap
 from collections import OrderedDict
 from decimal import Decimal
@@ -322,8 +321,8 @@ def force_serializer_instance(serializer):
 
 
 def get_serializer_class(serializer):
-    """Given a ``Serializer`` class or instance, return the ``Serializer`` class. If `serializer` is not a ``Serializer``
-    class or instance, raises an assertion error.
+    """Given a ``Serializer`` class or instance, return the ``Serializer`` class.
+    If `serializer` is not a ``Serializer`` class or instance, raises an assertion error.
 
     :param serializer: serializer class or instance, or ``None``
     :return: serializer class

--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -505,16 +505,3 @@ def get_field_default(field):
                 default = serializers.empty
 
     return default
-
-
-def dict_has_ordered_keys(obj):
-    """Check if a given object is a dict that maintains insertion order.
-
-    :param obj: the dict object to check
-    :rtype: bool
-    """
-    if sys.version_info >= (3, 7):
-        # the Python 3.7 language spec says that dict must maintain insertion order.
-        return isinstance(obj, dict)
-
-    return isinstance(obj, OrderedDict)

--- a/src/drf_yasg/views.py
+++ b/src/drf_yasg/views.py
@@ -51,7 +51,7 @@ def get_schema_view(info=None, url=None, patterns=None, urlconf=None, public=Fal
                     generator_class=None, authentication_classes=None, permission_classes=None):
     """Create a SchemaView class with default renderers and generators.
 
-    :param .Info info: information about the API; if omitted, defaults to :ref:`DEFAULT_INFO <default-swagger-settings>`
+    :param Info info: information about the API; if omitted, defaults to :ref:`DEFAULT_INFO <default-swagger-settings>`
     :param str url: same as :class:`.OpenAPISchemaGenerator`
     :param patterns: same as :class:`.OpenAPISchemaGenerator`
     :param urlconf: same as :class:`.OpenAPISchemaGenerator`

--- a/testproj/todo/urls.py
+++ b/testproj/todo/urls.py
@@ -8,7 +8,7 @@ router.register(r'', views.TodoViewSet)
 router.register(r'another', views.TodoAnotherViewSet)
 router.register(r'yetanother', views.TodoYetAnotherViewSet)
 router.register(r'tree', views.TodoTreeView)
-router.register(r'recursive', views.TodoRecursiveView)
+router.register(r'recursive', views.TodoRecursiveView, basename='todorecursivetree')
 router.register(r'harvest', views.HarvestViewSet)
 
 urlpatterns = router.urls

--- a/testproj/users/serializers.py
+++ b/testproj/users/serializers.py
@@ -77,6 +77,7 @@ class UserSerializer(serializers.ModelSerializer):
 
         ref_name = "UserSerializer"
 
+
 class UserListQuerySerializer(serializers.Serializer):
     username = serializers.CharField(help_text="this field is generated from a query_serializer", required=False)
     is_staff = serializers.BooleanField(help_text="this one too!", required=False)

--- a/tests/test_reference_schema.py
+++ b/tests/test_reference_schema.py
@@ -1,4 +1,5 @@
 import json
+import enum
 from collections import OrderedDict
 
 from drf_yasg import openapi
@@ -8,6 +9,11 @@ from drf_yasg.inspectors import FieldInspector, FilterInspector, PaginatorInspec
 
 def test_reference_schema(swagger_dict, reference_schema, compare_schemas):
     compare_schemas(swagger_dict, reference_schema)
+
+
+class VerisonEnum(enum.Enum):
+    V1 = 'v1'
+    V2 = 'v2'
 
 
 class NoOpFieldInspector(FieldInspector):
@@ -38,8 +44,8 @@ def test_noop_inspectors(swagger_settings, mock_schema_request, codec_json, refe
     set_inspectors([NoOpPaginatorInspector], 'DEFAULT_PAGINATOR_INSPECTORS')
 
     generator = OpenAPISchemaGenerator(
-        info=openapi.Info(title="Test generator", default_version="v1"),
-        version="v2",
+        info=openapi.Info(title="Test generator", default_version=VerisonEnum.V1),
+        version=VerisonEnum.V2,
     )
     swagger = generator.get_schema(mock_schema_request, True)
 

--- a/tests/test_reference_schema.py
+++ b/tests/test_reference_schema.py
@@ -1,5 +1,5 @@
-import json
 import enum
+import json
 from collections import OrderedDict
 
 from drf_yasg import openapi

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     py{37,38,39}-django{22,30}-drf{310,311,312},
     py{37,38,39}-django{31,32}-drf{311,312},
     py{39,310}-django{40,41}-drf{313,314}
+    py311-django{40,41}-drf314
     py38-{lint, docs},
     py39-djmaster
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist =
     py{39,310}-django{40,41}-drf{313,314}
     py311-django{40,41}-drf314
     py38-{lint, docs},
-    py39-djmaster
+    py310-djmaster
 
 skip_missing_interpreters = true
 
@@ -18,7 +18,7 @@ skip_missing_interpreters = true
 # no additional dependencies besides PEP 517
 deps =
 
-[testenv:py39-djmaster]
+[testenv:py310-djmaster]
 ignore_outcome = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -50,14 +50,14 @@ deps =
 commands =
     pytest -n 2 --cov --cov-config .coveragerc --cov-append --cov-report="" {posargs}
 
-[testenv:lint]
+[testenv:py38-lint]
 skip_install = true
 deps =
     -r requirements/lint.txt
 commands =
     flake8 src/drf_yasg testproj tests setup.py
 
-[testenv:docs]
+[testenv:py38-docs]
 deps =
     -r requirements/docs.txt
 commands =
@@ -72,7 +72,7 @@ addopts = --ignore=node_modules
 [flake8]
 max-line-length = 120
 exclude = **/migrations/*
-ignore = F405,W504
+ignore = F405,W504,I001,I005
 
 [isort]
 skip = .eggs,.tox,docs,env,venv,node_modules,.git


### PR DESCRIPTION
We ran into bugs when using Enum objects in inspectors. Due to this problem, the schema could not be rendered via the generate_swagger command.