### PR TITLE
keep path parameters in their given order

### DIFF
--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -495,7 +495,7 @@ class OpenAPISchemaGenerator(object):
         parameters = []
         queryset = get_queryset_from_view(view_cls)
 
-        for variable in sorted(uritemplate.variables(path)):
+        for variable in uritemplate.variables(path):
             model, model_field = get_queryset_field(queryset, variable)
             attrs = get_basic_type_info(model_field) or {'type': openapi.TYPE_STRING}
             if getattr(view_cls, 'lookup_field', None) == variable and attrs['type'] == openapi.TYPE_STRING:


### PR DESCRIPTION
This change keeps path parameters in their given order as tools like https://github.com/swagger-api/swagger-codegen/ use the parameter ordering as is to create a function signature. Arguably the tools could re-parse the path looking for template variables and use that ordering but it appears they do not.

The swagger spec does not seem like it documents how these parameters should be ordered, and while when reading the schema document, alphabetically ordered might make sense for a human to verify the parameters exist, it's losing information about the ordering which may be conveying additional information.