### PR TITLE
Upgrade deprecated pkg_resources

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ import sphinx_rtd_theme
 from docutils import nodes, utils
 from docutils.parsers.rst import roles
 from docutils.parsers.rst.roles import set_classes
-from pkg_resources import get_distribution
+from importlib.metadata import version
 
 # -- General configuration ------------------------------------------------
 
@@ -47,7 +47,7 @@ author = 'Cristi V.'
 # built documents.
 
 # The full version, including alpha/beta/rc tags.
-release = get_distribution('drf_yasg').version
+release = version('drf_yasg')
 if 'noscm' in release:
     raise AssertionError('Invalid package version string: %s. \n'
                          'The documentation must be built with drf_yasg installed from a distribution package, '

--- a/src/drf_yasg/__init__.py
+++ b/src/drf_yasg/__init__.py
@@ -1,11 +1,11 @@
 # coding=utf-8
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version, PackageNotFoundError
 
 __author__ = """Cristi V."""
 __email__ = 'cristi@cvjd.me'
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:  # pragma: no cover
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass


### PR DESCRIPTION

Locally, I'm running tests and getting deprecation warnings for the use of `pkg_resources`. According to [this post](https://setuptools.pypa.io/en/latest/pkg_resources.html):

---

Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Users should refrain from new usage of pkg_resources and should work to port to importlib-based solutions.

---

This PR makes the changes to follow the deprecation notice.