### PR TITLE
Feature: Add ``drf_yasg.inspectors.query.DrfAPICompatInspector``.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -114,6 +114,18 @@ Paginator inspectors given to :func:`@swagger_auto_schema <.swagger_auto_schema>
 :class:`'drf_yasg.inspectors.CoreAPICompatInspector' <.inspectors.CoreAPICompatInspector>`, |br| \
 ``]``
 
+DEFAULT_SPEC_RENDERERS
+----------------------
+
+List of spec renderers classes which used for plain schema rendering.
+
+**Default**: ``[``  |br| \
+:class:`'drf_yasg.renderers.SwaggerYAMLRenderer' <.renderers.SwaggerYAMLRenderer>`, |br| \
+:class:`'drf_yasg.renderers.SwaggerJSONRenderer' <.renderers.SwaggerJSONRenderer>`, |br| \
+:class:`'drf_yasg.renderers.OpenAPIRenderer' <.renderers.OpenAPIRenderer>`, |br| \
+``]``
+
+
 Swagger document attributes
 ===========================
 

--- a/src/drf_yasg/app_settings.py
+++ b/src/drf_yasg/app_settings.py
@@ -20,10 +20,12 @@ SWAGGER_DEFAULTS = {
         'drf_yasg.inspectors.StringDefaultFieldInspector',
     ],
     'DEFAULT_FILTER_INSPECTORS': [
+        'drf_yasg.inspectors.DrfAPICompatInspector',
         'drf_yasg.inspectors.CoreAPICompatInspector',
     ],
     'DEFAULT_PAGINATOR_INSPECTORS': [
         'drf_yasg.inspectors.DjangoRestResponsePagination',
+        'drf_yasg.inspectors.DrfAPICompatInspector',
         'drf_yasg.inspectors.CoreAPICompatInspector',
     ],
 

--- a/src/drf_yasg/app_settings.py
+++ b/src/drf_yasg/app_settings.py
@@ -27,6 +27,12 @@ SWAGGER_DEFAULTS = {
         'drf_yasg.inspectors.CoreAPICompatInspector',
     ],
 
+    'DEFAULT_SPEC_RENDERERS': [
+        'drf_yasg.renderers.SwaggerYAMLRenderer',
+        'drf_yasg.renderers.SwaggerJSONRenderer',
+        'drf_yasg.renderers.OpenAPIRenderer',
+    ],
+
     'EXCLUDED_MEDIA_TYPES': ['html'],
 
     'DEFAULT_INFO': None,
@@ -88,6 +94,7 @@ IMPORT_STRINGS = [
     'DEFAULT_FIELD_INSPECTORS',
     'DEFAULT_FILTER_INSPECTORS',
     'DEFAULT_PAGINATOR_INSPECTORS',
+    'DEFAULT_SPEC_RENDERERS',
     'DEFAULT_INFO',
 ]
 

--- a/src/drf_yasg/inspectors/__init__.py
+++ b/src/drf_yasg/inspectors/__init__.py
@@ -7,7 +7,7 @@ from .field import (
     InlineSerializerInspector, JSONFieldInspector, RecursiveFieldInspector, ReferencingSerializerInspector,
     RelatedFieldInspector, SerializerMethodFieldInspector, SimpleFieldInspector, StringDefaultFieldInspector
 )
-from .query import CoreAPICompatInspector, DjangoRestResponsePagination
+from .query import DrfAPICompatInspector, CoreAPICompatInspector, DjangoRestResponsePagination
 from .view import SwaggerAutoSchema
 
 # these settings must be accessed only after defining/importing all the classes in this module to avoid ImportErrors
@@ -20,7 +20,7 @@ __all__ = [
     'BaseInspector', 'FilterInspector', 'PaginatorInspector', 'FieldInspector', 'SerializerInspector', 'ViewInspector',
 
     # filter and pagination inspectors
-    'CoreAPICompatInspector', 'DjangoRestResponsePagination',
+    'DrfAPICompatInspector', 'CoreAPICompatInspector', 'DjangoRestResponsePagination',
 
     # field inspectors
     'InlineSerializerInspector', 'RecursiveFieldInspector', 'ReferencingSerializerInspector', 'RelatedFieldInspector',

--- a/src/drf_yasg/views.py
+++ b/src/drf_yasg/views.py
@@ -11,11 +11,13 @@ from rest_framework.views import APIView
 
 from .app_settings import swagger_settings
 from .renderers import (
-    OpenAPIRenderer, ReDocOldRenderer, ReDocRenderer, SwaggerJSONRenderer, SwaggerUIRenderer, SwaggerYAMLRenderer,
-    _SpecRenderer
+    ReDocOldRenderer,
+    ReDocRenderer,
+    SwaggerUIRenderer,
+    _SpecRenderer,
 )
 
-SPEC_RENDERERS = (SwaggerYAMLRenderer, SwaggerJSONRenderer, OpenAPIRenderer)
+SPEC_RENDERERS = swagger_settings.DEFAULT_SPEC_RENDERERS
 UI_RENDERERS = {
     'swagger': (SwaggerUIRenderer, ReDocRenderer),
     'redoc': (ReDocRenderer, SwaggerUIRenderer),

--- a/testproj/articles/views.py
+++ b/testproj/articles/views.py
@@ -12,16 +12,16 @@ from articles import serializers
 from articles.models import Article
 from drf_yasg import openapi
 from drf_yasg.app_settings import swagger_settings
-from drf_yasg.inspectors import CoreAPICompatInspector, FieldInspector, NotHandled, SwaggerAutoSchema
+from drf_yasg.inspectors import DrfAPICompatInspector, FieldInspector, NotHandled, SwaggerAutoSchema
 from drf_yasg.utils import no_body, swagger_auto_schema
 
 
-class DjangoFilterDescriptionInspector(CoreAPICompatInspector):
+class DjangoFilterDescriptionInspector(DrfAPICompatInspector):
     def get_filter_parameters(self, filter_backend):
         if isinstance(filter_backend, DjangoFilterBackend):
             result = super(DjangoFilterDescriptionInspector, self).get_filter_parameters(filter_backend)
             for param in result:
-                if not param.get('description', ''):
+                if not param.get('description', '') or param.get('description') == param.name:
                     param.description = "Filter the returned list by {field_name}".format(field_name=param.name)
 
             return result

--- a/testproj/testproj/settings/base.py
+++ b/testproj/testproj/settings/base.py
@@ -145,6 +145,7 @@ SWAGGER_SETTINGS = {
     "DEFAULT_PAGINATOR_INSPECTORS": [
         'testproj.inspectors.UnknownPaginatorInspector',
         'drf_yasg.inspectors.DjangoRestResponsePagination',
+        'drf_yasg.inspectors.DrfAPICompatInspector',
         'drf_yasg.inspectors.CoreAPICompatInspector',
     ]
 }

--- a/tox.ini
+++ b/tox.ini
@@ -47,8 +47,8 @@ deps =
     # other dependencies
     -r requirements/validation.txt
     -r requirements/test.txt
-    coreapi>=2.3.3
-    coreschema>=0.0.4
+    drf310: coreapi>=2.3.3
+    drf310: coreschema>=0.0.4
 
 commands =
     pytest -n 2 --cov --cov-config .coveragerc --cov-append --cov-report="" {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     py{37,38,39}-django{22,30}-drf{310,311,312},
     py{37,38,39}-django{31,32}-drf{311,312},
     py{39,310}-django{40,41}-drf{313,314}
-    py311-django{40,41}-drf314
+    py311-django{40,41,42}-drf314
     py38-{lint, docs},
     py310-djmaster
 
@@ -29,6 +29,7 @@ deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<5
 
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12


### PR DESCRIPTION
### Changelog:
* [Feature: Enable tests for django 4.2.](https://github.com/axnsan12/drf-yasg/commit/757db895dda5b480e46c18f50b457a491baa1604)
* [Feature: Add drf_yasg.inspectors.query.DrfAPICompatInspector.](https://github.com/axnsan12/drf-yasg/commit/dbf3548afa3ccc2f083a116338e0d45d20111ea2)
* [Feature: Provide to override default renderers via settings.](https://github.com/axnsan12/drf-yasg/commit/4edf7da2530a2d765ce38a9fa529a59277702502)
* [Docs: Add information how to override DEFAULT_SPEC_RENDERERS.](https://github.com/axnsan12/drf-yasg/commit/b19a1af32be2cd67524bf3056f98f98a7fec0237)

Fix #856