### PR TITLE
Update `tox.ini` to test more versions of `django` / `djangorestframework`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@ Generate **real** Swagger/OpenAPI 2.0 specifications from a Django Rest Framewor
 
 Compatible with
 
-- **Django Rest Framework**: 3.10, 3.11, 3.12, 3.13, 3.14
-- **Django**: 2.2, 3.0, 3.1, 3.2, 4.0, 4.1
+- **Django Rest Framework**: 3.10, 3.11, 3.12, 3.13, 3.14, 3.15
+- **Django**: 2.2, 3.0, 3.1, 3.2, 4.0, 4.1, 4.2, 5.0
 - **Python**: 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
 
 Only the latest patch version of each ``major.minor`` series of Python, Django and Django REST Framework is supported.

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -189,7 +189,7 @@ def get_queryset_from_view(view, serializer=None):
 
         if queryset is not None and serializer is not None:
             # make sure the view is actually using *this* serializer
-            assert type(serializer) == call_view_method(view, 'get_serializer_class', 'serializer_class')
+            assert type(serializer) is call_view_method(view, 'get_serializer_class', 'serializer_class')
 
         return queryset
     except Exception:  # pragma: no cover

--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -88,7 +88,7 @@ class SwaggerDict(OrderedDict):
     def __init__(self, **attrs):
         super(SwaggerDict, self).__init__()
         self._extras__ = attrs
-        if type(self) == SwaggerDict:
+        if type(self) is SwaggerDict:
             self._insert_extras__()
 
     def __setattr__(self, key, value):
@@ -516,7 +516,7 @@ class _Ref(SwaggerDict):
         :param bool ignore_unresolved: do not throw if the referenced object does not exist
         """
         super(_Ref, self).__init__()
-        assert not type(self) == _Ref, "do not instantiate _Ref directly"
+        assert type(self) is not _Ref, "do not instantiate _Ref directly"
         ref_name = "#/{scope}/{name}".format(scope=scope, name=name)
         if not ignore_unresolved:
             obj = resolver.get(name, scope)

--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -442,7 +442,7 @@ def force_real_str(s, encoding='utf-8', strings_only=False, errors='strict'):
     """
     if s is not None:
         s = force_str(s, encoding, strings_only, errors)
-        if type(s) != str:
+        if type(s) is not str:  # noqa: E721
             s = '' + s
 
         # Remove common indentation to get the correct Markdown rendering

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,13 @@ isolated_build_env = .package
 
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py{37,38,39}-django{22,30}-drf{310,311,312},
-    py{37,38,39}-django{31,32}-drf{311,312},
-    py{39,310}-django{40,41}-drf{313,314}
-    py311-django{40,41,42}-drf314
-    py38-{lint, docs},
-    py310-djmaster
+    py{37,38,39}-django{22,30}-drf{310,311,312}
+    py{37,38,39}-django{31,32}-drf{311,312}
+    py{38,39,310}-django{40,41}-drf{313,314,315}
+    py{38,39,310,311}-django42-drf{314,315}
+    py{310,311}-django50-drf{314,315}
+    py38-{lint,docs}
+    py311-djmaster
 
 skip_missing_interpreters = true
 
@@ -29,13 +30,15 @@ deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
-    django42: Django>=4.2,<5
+    django42: Django>=4.2,<5.0
+    django50: Django>=5.0,<5.1
 
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13
     drf313: djangorestframework>=3.13,<3.14
     drf314: djangorestframework>=3.14,<3.15
+    drf315: djangorestframework>=3.15,<3.16
 
     typing: typing>=3.6.6
 


### PR DESCRIPTION
## Rationale

Given the new release of [`djangorestframework==3.15`](https://www.django-rest-framework.org/community/3.15-announcement/) the `tox.ini` file should be updated so that we are still testing against relevant Python / `django` / `djangorestframework` combinations.

This PR doesn't actually include any material code changes, it just adds new test combinations which already appear to pass in CI.

The existing PR #873 addresses adding support for Python 3.12, and given this appears to require material changes I haven't touched that here.

## Changes

* Updates `README.rst` supported `django` / `djangorestframework` versions
* Adds more `django` / `djangorestframework` version combinations to `tox.ini`
* Fixes minor linting issues that caused CI failure