### PR TITLE
Fix Import Error in Sample Code Snippet in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ In ``urls.py``:
 .. code:: python
 
    ...
-   from django.urls import re_path
+   from django.urls import path
    from rest_framework import permissions
    from drf_yasg.views import get_schema_view
    from drf_yasg import openapi


### PR DESCRIPTION
The Quickstart section in the README.rst file contains a sample code snippet for urls.py that incorrectly imports re_path:

```
...
from django.urls import re_path
...
urlpatterns = [
   path('swagger<format>/', schema_view.without_ui(cache_timeout=0), name='schema-json'),
   path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
   path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
   ...
]
```

This PR addresses the issue by correcting the import statement. The re_path import is unnecessary and should be replaced with path:

```

...
from django.urls import path
...
```