### PR TITLE
GitHub Actions: review: strategy: fail-fast: false

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -7,6 +7,7 @@ jobs:
     name: Run linters and tests
     runs-on: "ubuntu-20.04"
     strategy:
+      fail-fast: false
       matrix:
         python: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 


### PR DESCRIPTION
When we test changes from Python 3.6 through 3.13 and Django 2.2 to 5.2, some versions will pass CI tests, and others will fail.  Give contributors more insight on which are which so they can focus on properly fixing the failures.

https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast