### PR TITLE
README.rst: pip install --upgrade

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,14 +102,14 @@ The preferred installation method is directly from pypi:
 
 .. code:: console
 
-   pip install -U drf-yasg
+   pip install --upgrade drf-yasg
 
 Additionally, if you want to use the built-in validation mechanisms (see `4. Validation`_), you need to install
 some extra requirements:
 
 .. code:: console
 
-   pip install -U drf-yasg[validation]
+   pip install --upgrade drf-yasg[validation]
 
 .. _readme-quickstart:
 
@@ -297,7 +297,7 @@ You can use the specification outputted by this library together with
 
    $ docker run --rm -v ${PWD}:/local swaggerapi/swagger-codegen-cli generate -i /local/tests/reference.yaml -l javascript -o /local/.codegen/js
 
-See the github page linked above for more details.
+See the GitHub page linked above for more details.
 
 .. _readme-testproj:
 
@@ -313,8 +313,8 @@ For additional usage examples, you can take a look at the test project in the ``
    $ virtualenv venv
    $ source venv/bin/activate
    (venv) $ cd testproj
-   (venv) $ python -m pip install -U pip setuptools
-   (venv) $ pip install -U -r requirements.txt
+   (venv) $ python -m pip install --upgrade pip setuptools
+   (venv) $ pip install --upgrade -r requirements.txt
    (venv) $ python manage.py migrate
    (venv) $ python manage.py runserver
    (venv) $ firefox localhost:8000/swagger/


### PR DESCRIPTION
```diff
-   pip install -U drf-yasg
+   pip install --upgrade drf-yasg
```
`pip install` currently has six `--u*` options so in code that will be read by others, let's use the most self-documenting form of the command.

% `pip install --help | grep "\-\-u"`
```
                              <dir>. Use --upgrade to replace existing
  --user                      Install to the Python user install directory for
  -U, --upgrade               Upgrade all specified packages to the newest
  --upgrade-strategy <upgrade_strategy>
  --use-pep517                Use PEP 517 for building source distributions
  --use-feature <feature>     Enable new functionality, that may be backward
  --use-deprecated <feature>  Enable deprecated functionality, that will be
```