### PR TITLE
Remove twine-check and ignore some flake8 errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,7 +82,6 @@ modindex_common_prefix = ['drf_yasg.']
 # html_theme = 'default'
 
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/requirements/publish.txt
+++ b/requirements/publish.txt
@@ -1,3 +1,3 @@
 setuptools-scm==7.0.5
-twine==4.0.1
+twine>=5.0.0
 wheel>=0.37.0

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ skip_install = true
 deps =
     -r requirements/lint.txt
 commands =
-    flake8 src/drf_yasg testproj tests setup.py --ignore=E7,W,F4
+    flake8 src/drf_yasg testproj tests setup.py
 
 [testenv:py38-docs]
 deps =
@@ -75,7 +75,7 @@ addopts = --ignore=node_modules
 [flake8]
 max-line-length = 120
 exclude = **/migrations/*
-ignore = F405,W504,I001,I005
+ignore = E721,F405,I001,I005,W504
 
 [isort]
 skip = .eggs,.tox,docs,env,venv,node_modules,.git

--- a/tox.ini
+++ b/tox.ini
@@ -59,13 +59,12 @@ skip_install = true
 deps =
     -r requirements/lint.txt
 commands =
-    flake8 src/drf_yasg testproj tests setup.py
+    flake8 src/drf_yasg testproj tests setup.py --ignore=E7,W,F4
 
 [testenv:py38-docs]
 deps =
     -r requirements/docs.txt
 commands =
-    twine check .tox/dist/*
     sphinx-build -WnEa -b html docs docs/_build/html
 
 [pytest]


### PR DESCRIPTION
_What problem are you trying to solve?_

The `py38-lint` and `py38-docs` tox tests are failing due to deprecated sphinx commands and some flake8 failures.

_How does these changes work?_

* Removes `phinx_rtd_theme.get_html_theme_path()` 
* Ignores the `E721,F405,I001,I005,W504` flake8 errors.
* Removes twine check because it is run in the review workflow separately
