### PR TITLE
Add Django v5.0 and v5.1 to the testing

### DIFF
--- a/testproj/testproj/settings/base.py
+++ b/testproj/testproj/settings/base.py
@@ -158,7 +158,6 @@ REDOC_SETTINGS = {
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)

--- a/testproj/testproj/settings/heroku.py
+++ b/testproj/testproj/settings/heroku.py
@@ -19,7 +19,14 @@ X_FRAME_OPTIONS = 'DENY'
 # Simplified static file serving.
 # https://warehouse.python.org/project/whitenoise/
 
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": 'whitenoise.storage.CompressedManifestStaticFilesStorage',
+    },
+}
 MIDDLEWARE.insert(0, 'whitenoise.middleware.WhiteNoiseMiddleware')
 
 # Database

--- a/testproj/testproj/urls.py
+++ b/testproj/testproj/urls.py
@@ -36,7 +36,7 @@ def plain_view(request):
 
 
 def root_redirect(request):
-    user_agent_string = request.META.get('HTTP_USER_AGENT', '')
+    user_agent_string = request.headers.get('user-agent', '')
     user_agent = user_agents.parse(user_agent_string)
 
     if user_agent.is_mobile:

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,11 @@ envlist =
     py{37,38,39}-django{22,30}-drf{310,311,312},
     py{37,38,39}-django{31,32}-drf{311,312},
     py{39,310}-django{40,41}-drf{313,314},
-    # py311-django{40,41,42,50,51}-drf314,
-    py311-django{40,41,42}-drf314,
-    # py312-django{42,50,51}-drf314,
-    py312-django{42}-drf314,
-    # py313-django{51}-drf314,
+    py311-django{40,41,42,50,51}-drf315,
+    py312-django{42,50,51}-drf315,
+    py313-django{51}-drf315,
     py38-{lint, docs},
-    # py313-djmaster
+    # py313-djmaster  # ModuleNotFoundError: No module named 'psycopg'
 
 skip_missing_interpreters = true
 
@@ -40,6 +38,7 @@ deps =
     drf312: djangorestframework>=3.12,<3.13
     drf313: djangorestframework>=3.13,<3.14
     drf314: djangorestframework>=3.14,<3.15
+    drf315: djangorestframework>=3.15,<3.16
 
     typing: typing>=3.6.6
 


### PR DESCRIPTION
* https://pypi.org/project/django-upgrade v1.22.1
* https://pypi.org/project/djangorestframework v3.15.2

% `django-upgrade --version`
```
1.22.1
```
% `django-upgrade --target-version=5.1 **/*.py`
```
Rewriting testproj/testproj/settings/base.py
Rewriting testproj/testproj/settings/heroku.py
Rewriting testproj/testproj/urls.py
```
__tox.ini__: `drf315: djangorestframework>=3.15,<3.16`