### PR TITLE
Lint Python code with ruff instead of flake8 and isort

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,10 +6,9 @@
 import inspect
 import os
 import re
-import sys
 import shutil
+import sys
 
-import sphinx_rtd_theme
 from docutils import nodes, utils
 from docutils.parsers.rst import roles
 from docutils.parsers.rst.roles import set_classes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,39 @@
 [build-system]
-requires = ["setuptools >= 68.0.0", "wheel", "setuptools-scm >= 3.0.3"]
 build-backend = "setuptools.build_meta"
+
+requires = [ "setuptools>=68", "setuptools-scm>=3.0.3", "wheel" ]
+
+[tool.ruff]
+exclude = [ "**/migrations/*" ]
+line-length = 88
+lint.select = [
+  "AIR",   # Airflow
+  "ASYNC", # flake8-async
+  "C4",    # flake8-comprehensions
+  "C90",   # mccabe
+  "E",     # pycodestyle errors
+  "F",     # Pyflakes
+  "FA",    # flake8-future-annotations
+  "FLY",   # flynt
+  "I",     # isort
+  "ICN",   # flake8-import-conventions
+  "INT",   # flake8-gettext
+  "LOG",   # flake8-logging
+  "NPY",   # NumPy-specific rules
+  "PD",    # pandas-vet
+  "PLE",   # Pylint errors
+  "PYI",   # flake8-pyi
+  "SLOT",  # flake8-slots
+  "T10",   # flake8-debugger
+  "TCH",   # flake8-type-checking
+  "W",     # pycodestyle warnings
+  "YTT",   # flake8-2020
+]
+lint.ignore = [ "E501" ]
+lint.isort.known-first-party = [ "drf_yasg", "testproj", "articles", "people", "snippets", "todo", "users", "urlconfs" ]
+lint.mccabe.max-complexity = 13
+lint.per-file-ignores."src/drf_yasg/inspectors/field.py" = [ "E721" ]
+lint.per-file-ignores."src/drf_yasg/openapi.py" = [ "E721" ]
+lint.per-file-ignores."testproj/testproj/settings/*" = [ "F405" ]
+
+[tool.setuptools_scm]

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,4 +1,2 @@
-# used by the 'lint' tox env for linting via flake8
-isort>=5.12
-flake8>=6.0.0
-flake8-isort>=6.0.0
+# used by the 'lint' tox env for linting via ruff
+ruff>=0.11.0

--- a/src/drf_yasg/codecs.py
+++ b/src/drf_yasg/codecs.py
@@ -3,8 +3,8 @@ import json
 import logging
 from collections import OrderedDict
 
-from django.utils.encoding import force_bytes
 import yaml
+from django.utils.encoding import force_bytes
 
 try:
     from swagger_spec_validator.common import SwaggerValidationError as SSVErr

--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -7,16 +7,20 @@ from collections import OrderedDict, defaultdict
 import uritemplate
 from django.urls import URLPattern, URLResolver
 from rest_framework import versioning
-from rest_framework.schemas.openapi import SchemaGenerator
 from rest_framework.schemas.generators import EndpointEnumerator as _EndpointEnumerator
 from rest_framework.schemas.generators import endpoint_ordering, get_pk_name
+from rest_framework.schemas.openapi import SchemaGenerator
 from rest_framework.schemas.utils import get_pk_description, is_list_view
 from rest_framework.settings import api_settings
 
 from . import openapi
 from .app_settings import swagger_settings
 from .errors import SwaggerGenerationError
-from .inspectors.field import get_basic_type_info, get_queryset_field, get_queryset_from_view
+from .inspectors.field import (
+    get_basic_type_info,
+    get_queryset_field,
+    get_queryset_from_view,
+)
 from .openapi import ReferenceResolver, SwaggerDict
 from .utils import force_real_str, get_consumes, get_produces
 

--- a/src/drf_yasg/inspectors/__init__.py
+++ b/src/drf_yasg/inspectors/__init__.py
@@ -1,13 +1,33 @@
 from ..app_settings import swagger_settings
 from .base import (
-    BaseInspector, FieldInspector, FilterInspector, NotHandled, PaginatorInspector, SerializerInspector, ViewInspector
+    BaseInspector,
+    FieldInspector,
+    FilterInspector,
+    NotHandled,
+    PaginatorInspector,
+    SerializerInspector,
+    ViewInspector,
 )
 from .field import (
-    CamelCaseJSONFilter, ChoiceFieldInspector, DictFieldInspector, FileFieldInspector, HiddenFieldInspector,
-    InlineSerializerInspector, JSONFieldInspector, RecursiveFieldInspector, ReferencingSerializerInspector,
-    RelatedFieldInspector, SerializerMethodFieldInspector, SimpleFieldInspector, StringDefaultFieldInspector
+    CamelCaseJSONFilter,
+    ChoiceFieldInspector,
+    DictFieldInspector,
+    FileFieldInspector,
+    HiddenFieldInspector,
+    InlineSerializerInspector,
+    JSONFieldInspector,
+    RecursiveFieldInspector,
+    ReferencingSerializerInspector,
+    RelatedFieldInspector,
+    SerializerMethodFieldInspector,
+    SimpleFieldInspector,
+    StringDefaultFieldInspector,
 )
-from .query import DrfAPICompatInspector, CoreAPICompatInspector, DjangoRestResponsePagination
+from .query import (
+    CoreAPICompatInspector,
+    DjangoRestResponsePagination,
+    DrfAPICompatInspector,
+)
 from .view import SwaggerAutoSchema
 
 # these settings must be accessed only after defining/importing all the classes in this module to avoid ImportErrors

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -2,24 +2,28 @@ import datetime
 import inspect
 import logging
 import operator
+import typing
 import uuid
-from contextlib import suppress
 from collections import OrderedDict
+from contextlib import suppress
 from decimal import Decimal
 
-import typing
 from django.core import validators
 from django.db import models
 from packaging import version
 from rest_framework import serializers
 from rest_framework.settings import api_settings as rest_framework_settings
 
-from .base import call_view_method, FieldInspector, NotHandled, SerializerInspector
 from .. import openapi
 from ..errors import SwaggerGenerationError
 from ..utils import (
-    decimal_as_float, field_value_to_representation, filter_none, get_serializer_class, get_serializer_ref_name
+    decimal_as_float,
+    field_value_to_representation,
+    filter_none,
+    get_serializer_class,
+    get_serializer_ref_name,
 )
+from .base import FieldInspector, NotHandled, SerializerInspector, call_view_method
 
 try:
     from importlib import metadata

--- a/src/drf_yasg/inspectors/query.py
+++ b/src/drf_yasg/inspectors/query.py
@@ -8,7 +8,7 @@ except ImportError:
 
 from .. import openapi
 from ..utils import force_real_str
-from .base import FilterInspector, PaginatorInspector, NotHandled
+from .base import FilterInspector, NotHandled, PaginatorInspector
 
 
 def ignore_assert_decorator(func):

--- a/src/drf_yasg/inspectors/view.py
+++ b/src/drf_yasg/inspectors/view.py
@@ -8,8 +8,15 @@ from rest_framework.status import is_success
 from .. import openapi
 from ..errors import SwaggerGenerationError
 from ..utils import (
-    filter_none, force_real_str, force_serializer_instance, get_consumes, get_produces, guess_response_status,
-    merge_params, no_body, param_list_to_odict
+    filter_none,
+    force_real_str,
+    force_serializer_instance,
+    get_consumes,
+    get_produces,
+    guess_response_status,
+    merge_params,
+    no_body,
+    param_list_to_odict,
 )
 from .base import ViewInspector, call_view_method
 

--- a/src/drf_yasg/openapi.py
+++ b/src/drf_yasg/openapi.py
@@ -2,7 +2,8 @@ import enum
 import logging
 import re
 import urllib.parse as urlparse
-from collections import OrderedDict, abc as collections_abc
+from collections import OrderedDict
+from collections import abc as collections_abc
 
 from django.urls import get_script_prefix
 from django.utils.functional import Promise
@@ -516,7 +517,7 @@ class _Ref(SwaggerDict):
         :param bool ignore_unresolved: do not throw if the referenced object does not exist
         """
         super(_Ref, self).__init__()
-        assert not type(self) is _Ref, "do not instantiate _Ref directly"
+        assert type(self) is not _Ref, "do not instantiate _Ref directly"
         ref_name = "#/{scope}/{name}".format(scope=scope, name=name)
         if not ignore_unresolved:
             obj = resolver.get(name, scope)

--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -8,7 +8,12 @@ import pytz
 from django.db import models
 from django.utils.encoding import force_str
 from rest_framework import serializers, status
-from rest_framework.mixins import DestroyModelMixin, ListModelMixin, RetrieveModelMixin, UpdateModelMixin
+from rest_framework.mixins import (
+    DestroyModelMixin,
+    ListModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+)
 from rest_framework.parsers import FileUploadParser
 from rest_framework.request import is_form_media_type
 from rest_framework.settings import api_settings as rest_framework_settings
@@ -451,7 +456,7 @@ def force_real_str(s, encoding='utf-8', strings_only=False, errors='strict'):
     """
     if s is not None:
         s = force_str(s, encoding, strings_only, errors)
-        if type(s) is not str:
+        if not isinstance(s, str):
             s = '' + s
 
         # Remove common indentation to get the correct Markdown rendering

--- a/testproj/articles/views.py
+++ b/testproj/articles/views.py
@@ -12,7 +12,12 @@ from articles import serializers
 from articles.models import Article
 from drf_yasg import openapi
 from drf_yasg.app_settings import swagger_settings
-from drf_yasg.inspectors import DrfAPICompatInspector, FieldInspector, NotHandled, SwaggerAutoSchema
+from drf_yasg.inspectors import (
+    DrfAPICompatInspector,
+    FieldInspector,
+    NotHandled,
+    SwaggerAutoSchema,
+)
 from drf_yasg.utils import no_body, swagger_auto_schema
 
 

--- a/testproj/testproj/settings/heroku.py
+++ b/testproj/testproj/settings/heroku.py
@@ -1,3 +1,5 @@
+import os
+
 import dj_database_url
 
 from .base import *  # noqa: F403

--- a/testproj/todo/views.py
+++ b/testproj/todo/views.py
@@ -6,8 +6,12 @@ from drf_yasg.utils import swagger_auto_schema
 
 from .models import Pack, Todo, TodoAnother, TodoTree, TodoYetAnother
 from .serializer import (
-    HarvestSerializer, TodoAnotherSerializer, TodoRecursiveSerializer, TodoSerializer, TodoTreeSerializer,
-    TodoYetAnotherSerializer
+    HarvestSerializer,
+    TodoAnotherSerializer,
+    TodoRecursiveSerializer,
+    TodoSerializer,
+    TodoTreeSerializer,
+    TodoYetAnotherSerializer,
 )
 
 

--- a/tests/test_reference_schema.py
+++ b/tests/test_reference_schema.py
@@ -4,7 +4,12 @@ from collections import OrderedDict
 
 from drf_yasg import openapi
 from drf_yasg.generators import OpenAPISchemaGenerator
-from drf_yasg.inspectors import FieldInspector, FilterInspector, PaginatorInspector, SerializerInspector
+from drf_yasg.inspectors import (
+    FieldInspector,
+    FilterInspector,
+    PaginatorInspector,
+    SerializerInspector,
+)
 
 
 def test_reference_schema(swagger_dict, reference_schema, compare_schemas):

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,7 +1,7 @@
 import pytest
 
-from drf_yasg.errors import SwaggerGenerationError
 from drf_yasg.codecs import yaml_sane_load
+from drf_yasg.errors import SwaggerGenerationError
 
 
 def _get_versioned_schema(prefix, client, validate_schema, path='/snippets/'):

--- a/tests/urlconfs/additional_fields_checks.py
+++ b/tests/urlconfs/additional_fields_checks.py
@@ -3,7 +3,12 @@ from rest_framework import serializers
 
 from testproj.urls import required_urlpatterns
 
-from .url_versioning import SnippetList, SnippetSerializer, VersionedSchemaView, VERSION_PREFIX_URL
+from .url_versioning import (
+    VERSION_PREFIX_URL,
+    SnippetList,
+    SnippetSerializer,
+    VersionedSchemaView,
+)
 
 
 class SnippetsSerializer(serializers.HyperlinkedModelSerializer, SnippetSerializer):

--- a/tests/urlconfs/coreschema.py
+++ b/tests/urlconfs/coreschema.py
@@ -1,11 +1,11 @@
-from django.urls import re_path
 import coreapi
 import coreschema
+from django.urls import re_path
 from rest_framework import pagination
 
 from testproj.urls import required_urlpatterns
 
-from .url_versioning import SnippetList, VersionedSchemaView, VERSION_PREFIX_URL
+from .url_versioning import VERSION_PREFIX_URL, SnippetList, VersionedSchemaView
 
 
 class FilterBackendWithoutParams:

--- a/tests/urlconfs/legacy_renderer.py
+++ b/tests/urlconfs/legacy_renderer.py
@@ -1,6 +1,6 @@
 from django.urls import path, re_path
 
-from testproj.urls import required_urlpatterns, SchemaView
+from testproj.urls import SchemaView, required_urlpatterns
 
 urlpatterns = [
     re_path(r'^swagger(?P<format>\.json|\.yaml)$', SchemaView.without_ui(cache_timeout=0),

--- a/tests/urlconfs/url_versioning_extra.py
+++ b/tests/urlconfs/url_versioning_extra.py
@@ -2,7 +2,7 @@ from django.urls import re_path
 
 from testproj.urls import required_urlpatterns
 
-from .url_versioning import SnippetList, VERSION_PREFIX_URL, VersionedSchemaView
+from .url_versioning import VERSION_PREFIX_URL, SnippetList, VersionedSchemaView
 
 urlpatterns = required_urlpatterns + [
     re_path(VERSION_PREFIX_URL + r"extra/snippets/$", SnippetList.as_view()),

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ skip_install = true
 deps =
     -r requirements/lint.txt
 commands =
-    flake8 src/drf_yasg testproj tests setup.py
+    ruff check
 
 [testenv:py38-docs]
 deps =


### PR DESCRIPTION
https://docs.astral.sh/ruff
> Ruff can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [Black](https://github.com/psf/black), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [pyupgrade](https://pypi.org/project/pyupgrade/), [autoflake](https://pypi.org/project/autoflake/), and more, all while executing tens or hundreds of times faster than any individual tool.