### PR TITLE
Add django-filter version limit

### DIFF
--- a/requirements/testproj.txt
+++ b/requirements/testproj.txt
@@ -1,6 +1,6 @@
 # test project requirements
 Pillow>=4.3.0
-django-filter>=2.4.0
+django-filter>=2.4.0,<25
 djangorestframework-camel-case>=1.1.2
 djangorestframework-recursive>=0.1.2
 dj-database-url>=0.4.2


### PR DESCRIPTION
The `django-filter` package version [25.1](https://pypi.org/project/django-filter/25.1/) released on 14/02/2025. The `testproj.txt` file specifies `django-filter>=2.4.0` which matches the latest version. This has caused the tests to start failing. This PR adds an upper limit `django-filter>=2.4.0,<25` to resolve this.