### PR TITLE
fix list views with parameters in last path segment not named "list" views

### DIFF
--- a/src/drf_yasg/generators.py
+++ b/src/drf_yasg/generators.py
@@ -10,7 +10,7 @@ from rest_framework import versioning
 from rest_framework.schemas.generators import EndpointEnumerator as _EndpointEnumerator
 from rest_framework.schemas.generators import endpoint_ordering, get_pk_name
 from rest_framework.schemas.openapi import SchemaGenerator
-from rest_framework.schemas.utils import get_pk_description, is_list_view
+from rest_framework.schemas.utils import get_pk_description
 from rest_framework.settings import api_settings
 
 from . import openapi
@@ -22,7 +22,7 @@ from .inspectors.field import (
     get_queryset_from_view,
 )
 from .openapi import ReferenceResolver, SwaggerDict
-from .utils import force_real_str, get_consumes, get_produces
+from .utils import force_real_str, get_consumes, get_produces, is_list_view
 
 logger = logging.getLogger(__name__)
 

--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -315,18 +315,18 @@ def is_list_view(path, method, view):
     """
     # for ViewSets, it could be the default 'list' action, or an @action(detail=False)
     action = getattr(view, "action", "")
-    method = getattr(view, action, None) or method
-    detail = getattr(method, "detail", None)
+    detail = getattr(view, "detail", None)
     suffix = getattr(view, "suffix", None)
     if action in ("list", "create") or detail is False or suffix == "List":
         return True
 
     if (
         action in ("retrieve", "update", "partial_update", "destroy")
+        or method.lower() != "get"
+        # a detail action is surely not a list route
         or detail is True
         or suffix == "Instance"
     ):
-        # a detail action is surely not a list route
         return False
 
     if isinstance(view, ListModelMixin):

--- a/tests/reference.yaml
+++ b/tests/reference.yaml
@@ -448,7 +448,7 @@ paths:
     parameters: []
   /snippets/views/{snippet_pk}/:
     get:
-      operationId: snippetsViewsRead
+      operationId: snippetsViewsList
       description: SnippetViewerList classdoc
       parameters:
         - name: page

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -12,12 +12,12 @@ from drf_yasg.codecs import yaml_sane_load
 from drf_yasg.generators import OpenAPISchemaGenerator
 
 
-def test_reference_schema(call_generate_swagger, db, reference_schema):
+def test_reference_schema(call_generate_swagger, db, reference_schema, compare_schemas):
     output = call_generate_swagger(
         format="yaml", api_url="http://test.local:8002/", user="admin"
     )
     output_schema = yaml_sane_load(output)
-    assert output_schema == reference_schema
+    compare_schemas(output_schema, reference_schema)
 
 
 def test_non_public(call_generate_swagger, db):


### PR DESCRIPTION
This fixes the auto generated operation keys and operation ID. For list views which have a parameter in their last path segment.