### PR TITLE
update Python, Django, and DRF versions & packaging configuration

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements/*.txt') }}
         restore-keys: ${{ runner.os }}-pip-
 
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,18 +16,18 @@ jobs:
       - name: Set the python version
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.13
 
       - name: Install dependencies
         uses: ./.github/actions/install
         with:
-          python-version: 3.11
+          python-version: 3.13
 
       - name: Install builders for publishing
         run: pip install -r requirements/publish.txt
 
       - name: Build the distributions
-        run: python setup.py sdist bdist_wheel
+        run: python -m build --sdist --wheel
 
       - name: Publish the package
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -55,4 +55,4 @@ jobs:
         python: ["3.6", "3.7", "3.8", "3.9"]
 
     steps:
-      - run: echo "All tests passed!"
+      - run: echo "Deprecated tests skipped 🧪"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout the source code
@@ -36,10 +36,10 @@ jobs:
           coverage report
 
       - name: Check for incompatibilities with publishing to PyPi
-        if: ${{ matrix.python == 3.12 }}
+        if: ${{ matrix.python == 3.13 }}
         run: |
           pip install -r requirements/publish.txt
-          python setup.py sdist
+          python -m build --sdist
           twine check dist/*
 
   # Return successful statuses "Run linters and tests" for python {3.6...8}
@@ -48,8 +48,11 @@ jobs:
   review:
     name: Run linters and tests
     runs-on: ubuntu-latest
+    needs: test
     strategy:
+      fail-fast: false
       matrix:
         python: ["3.6", "3.7", "3.8", "3.9"]
+
     steps:
-      - run: exit 0
+      - run: echo "All tests passed!"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -36,8 +36,7 @@ You want to contribute some code? Great! Here are a few steps to get you started
       $ python -m venv venv
       $ source venv/bin/activate
       (venv) $ python -m pip install -U pip setuptools
-      (venv) $ pip install -U -e '.[validation]'
-      (venv) $ pip install -U -r requirements/dev.txt
+      (venv) $ pip install -U -r requirements/dev.txt -e '.[validation]'
 
 #. **Make your changes and check them against the test project**
 

--- a/README.rst
+++ b/README.rst
@@ -395,6 +395,8 @@ for display the Base64 fields correctly.
 Contributing
 ************
 
+See https://drf-yasg.readthedocs.io/en/stable/contributing.html for details.
+
 This repository adheres to semantic versioning standards. For more
 information on semantic versioning visit `SemVer <https://semver.org>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,9 @@ Generate **real** Swagger/OpenAPI 2.0 specifications from a Django Rest Framewor
 
 Compatible with
 
-- **Django Rest Framework**: 3.10, 3.11, 3.12, 3.13, 3.14
-- **Django**: 2.2, 3.0, 3.1, 3.2, 4.0, 4.1, 4.2
-- **Python**: 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12
+- **Django Rest Framework**: 3.13, 3.14, 3.15
+- **Django**: 4.0, 4.1, 4.2, 5.0, 5.1, 5.2
+- **Python**: 3.9, 3.10, 3.11, 3.12, 3.13
 
 Only the latest patch version of each ``major.minor`` series of Python, Django and Django REST Framework is supported.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,64 @@
 requires = [ "setuptools >= 77.0.3", "setuptools-scm ~= 7.0" ]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "drf-yasg"
+requires-python = ">= 3.9"
+dynamic = [ "dependencies", "optional-dependencies", "version" ]
+
+authors = [
+  { name = "Cristi V.", email = "cristi@cvjd.me" },
+]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Web Environment",
+  "Framework :: Django :: 4.0",
+  "Framework :: Django :: 4.1",
+  "Framework :: Django :: 4.2",
+  "Framework :: Django :: 5.0",
+  "Framework :: Django :: 5.1",
+  "Framework :: Django :: 5.2",
+  "Framework :: Django",
+  "Intended Audience :: Developers",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python",
+  "Topic :: Documentation",
+  "Topic :: Software Development :: Code Generators",
+]
+description = """Automated generation of real Swagger/OpenAPI 2.0 schemas \
+from Django Rest Framework code."""
+keywords = [
+  "codegen",
+  "django",
+  "django-rest-framework",
+  "django-rest-swagger",
+  "documentation",
+  "drf",
+  "drf-openapi",
+  "drf-yasg",
+  "openapi",
+  "schema",
+  "swagger",
+  "swagger-codegen",
+]
+license = "BSD-3-Clause"
+license-files = [ "LICENSE.rst" ]
+readme =  "README.rst"
+
+[project.urls]
+Changelog = "https://drf-yasg.readthedocs.io/en/stable/changelog.html"
+Documentation = "https://drf-yasg.readthedocs.io/en/stable/"
+Homepage = "https://github.com/axnsan12/drf-yasg"
+Issues = "https://github.com/axnsan12/drf-yasg/issues"
+Repository = "https://github.com/axnsan12/drf-yasg"
+
 [tool.ruff]
 exclude = [ "**/migrations/*" ]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "drf-yasg"
 requires-python = ">= 3.9"
-dynamic = [ "dependencies", "optional-dependencies", "version" ]
+dynamic = [ "version" ]
 
 authors = [
   { name = "Cristi V.", email = "cristi@cvjd.me" },
@@ -33,6 +33,15 @@ classifiers = [
   "Topic :: Documentation",
   "Topic :: Software Development :: Code Generators",
 ]
+dependencies = [
+  "django >= 4.0",
+  "djangorestframework >= 3.13",
+  "inflection >= 0.3.1",
+  "packaging >= 21.0",
+  "pytz >= 2021.1",
+  "pyyaml >= 5.1",
+  "uritemplate >= 3.0.0",
+]
 description = """Automated generation of real Swagger/OpenAPI 2.0 schemas \
 from Django Rest Framework code."""
 keywords = [
@@ -52,6 +61,10 @@ keywords = [
 license = "BSD-3-Clause"
 license-files = [ "LICENSE.rst" ]
 readme =  "README.rst"
+
+[project.optional-dependencies]
+coreapi = [ "coreapi >= 2.3.3", "coreschema >= 0.0.4" ]
+validation = [ "swagger-spec-validator >= 2.1.0" ]
 
 [project.urls]
 Changelog = "https://drf-yasg.readthedocs.io/en/stable/changelog.html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,74 +1,74 @@
 [build-system]
-requires = [ "setuptools >= 77.0.3", "setuptools-scm ~= 7.0" ]
+requires = ["setuptools >= 77.0.3", "setuptools-scm ~= 7.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "drf-yasg"
-requires-python = ">= 3.9"
-dynamic = [ "version" ]
+description = "Automated generation of real Swagger/OpenAPI 2.0 schemas from Django Rest Framework code."
 
-authors = [
-  { name = "Cristi V.", email = "cristi@cvjd.me" },
+requires-python = ">= 3.9"
+dynamic = ["version"]
+
+license = "BSD-3-Clause"
+license-files = ["LICENSE.rst"]
+readme = "README.rst"
+
+dependencies = [
+    "django >= 4.0",
+    "djangorestframework >= 3.13",
+    "inflection >= 0.3.1",
+    "packaging >= 21.0",
+    "pytz >= 2021.1",
+    "pyyaml >= 5.1",
+    "uritemplate >= 3.0.0",
+]
+
+keywords = [
+    "codegen",
+    "django",
+    "django-rest-framework",
+    "django-rest-swagger",
+    "documentation",
+    "drf",
+    "drf-openapi",
+    "drf-yasg",
+    "openapi",
+    "schema",
+    "swagger",
+    "swagger-codegen",
 ]
 
 classifiers = [
-  "Development Status :: 5 - Production/Stable",
-  "Environment :: Web Environment",
-  "Framework :: Django",
-  "Framework :: Django :: 4.0",
-  "Framework :: Django :: 4.1",
-  "Framework :: Django :: 4.2",
-  "Framework :: Django :: 5.0",
-  "Framework :: Django :: 5.1",
-  "Framework :: Django :: 5.2",
-  "Intended Audience :: Developers",
-  "Operating System :: OS Independent",
-  "Programming Language :: Python",
-  "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3 :: Only",
-  "Topic :: Documentation",
-  "Topic :: Software Development :: Code Generators",
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Web Environment",
+    "Framework :: Django",
+    "Framework :: Django :: 4.0",
+    "Framework :: Django :: 4.1",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Documentation",
+    "Topic :: Software Development :: Code Generators",
 ]
 
-dependencies = [
-  "django >= 4.0",
-  "djangorestframework >= 3.13",
-  "inflection >= 0.3.1",
-  "packaging >= 21.0",
-  "pytz >= 2021.1",
-  "pyyaml >= 5.1",
-  "uritemplate >= 3.0.0",
-]
-
-description = "Automated generation of real Swagger/OpenAPI 2.0 schemas from Django Rest Framework code."
-
-keywords = [
-  "codegen",
-  "django",
-  "django-rest-framework",
-  "django-rest-swagger",
-  "documentation",
-  "drf",
-  "drf-openapi",
-  "drf-yasg",
-  "openapi",
-  "schema",
-  "swagger",
-  "swagger-codegen",
-]
-
-license = "BSD-3-Clause"
-license-files = [ "LICENSE.rst" ]
-readme =  "README.rst"
+[[project.authors]]
+name = "Cristi V."
+email = "cristi@cvjd.me"
 
 [project.optional-dependencies]
-coreapi = [ "coreapi >= 2.3.3", "coreschema >= 0.0.4" ]
-validation = [ "swagger-spec-validator >= 2.1.0" ]
+coreapi = ["coreapi >= 2.3.3", "coreschema >= 0.0.4"]
+validation = ["swagger-spec-validator >= 2.1.0"]
 
 [project.urls]
 Changelog = "https://drf-yasg.readthedocs.io/en/stable/changelog.html"
@@ -78,33 +78,44 @@ Issues = "https://github.com/axnsan12/drf-yasg/issues"
 Repository = "https://github.com/axnsan12/drf-yasg"
 
 [tool.ruff]
-exclude = [ "**/migrations/*" ]
+exclude = ["**/migrations/*"]
 line-length = 88
 lint.select = [
-  "AIR",   # Airflow
-  "ASYNC", # flake8-async
-  "C4",    # flake8-comprehensions
-  "C90",   # mccabe
-  "E",     # pycodestyle errors
-  "F",     # Pyflakes
-  "FA",    # flake8-future-annotations
-  "FLY",   # flynt
-  "I",     # isort
-  "ICN",   # flake8-import-conventions
-  "INT",   # flake8-gettext
-  "LOG",   # flake8-logging
-  "NPY",   # NumPy-specific rules
-  "PD",    # pandas-vet
-  "PLE",   # Pylint errors
-  "PYI",   # flake8-pyi
-  "SLOT",  # flake8-slots
-  "T10",   # flake8-debugger
-  "TCH",   # flake8-type-checking
-  "W",     # pycodestyle warnings
-  "YTT",   # flake8-2020
+    "AIR",   # Airflow
+    "ASYNC", # flake8-async
+    "C4",    # flake8-comprehensions
+    "C90",   # mccabe
+    "E",     # pycodestyle errors
+    "F",     # Pyflakes
+    "FA",    # flake8-future-annotations
+    "FLY",   # flynt
+    "I",     # isort
+    "ICN",   # flake8-import-conventions
+    "INT",   # flake8-gettext
+    "LOG",   # flake8-logging
+    "NPY",   # NumPy-specific rules
+    "PD",    # pandas-vet
+    "PLE",   # Pylint errors
+    "PYI",   # flake8-pyi
+    "SLOT",  # flake8-slots
+    "T10",   # flake8-debugger
+    "TCH",   # flake8-type-checking
+    "W",     # pycodestyle warnings
+    "YTT",   # flake8-2020
 ]
-lint.isort.known-first-party = [ "drf_yasg", "testproj", "articles", "people", "snippets", "todo", "users", "urlconfs" ]
+
+lint.isort.known-first-party = [
+    "drf_yasg",
+    "testproj",
+    "articles",
+    "people",
+    "snippets",
+    "todo",
+    "users",
+    "urlconfs",
+]
+
 lint.mccabe.max-complexity = 13
-lint.per-file-ignores."src/drf_yasg/inspectors/field.py" = [ "E721" ]
-lint.per-file-ignores."src/drf_yasg/openapi.py" = [ "E721" ]
-lint.per-file-ignores."testproj/testproj/settings/*" = [ "F405" ]
+lint.per-file-ignores."src/drf_yasg/inspectors/field.py" = ["E721"]
+lint.per-file-ignores."src/drf_yasg/openapi.py" = ["E721"]
+lint.per-file-ignores."testproj/testproj/settings/*" = ["F405"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,29 +10,31 @@ dynamic = [ "version" ]
 authors = [
   { name = "Cristi V.", email = "cristi@cvjd.me" },
 ]
+
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
+  "Framework :: Django",
   "Framework :: Django :: 4.0",
   "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",
   "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
-  "Framework :: Django",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
   "Topic :: Documentation",
   "Topic :: Software Development :: Code Generators",
 ]
+
 dependencies = [
   "django >= 4.0",
   "djangorestframework >= 3.13",
@@ -42,8 +44,9 @@ dependencies = [
   "pyyaml >= 5.1",
   "uritemplate >= 3.0.0",
 ]
-description = """Automated generation of real Swagger/OpenAPI 2.0 schemas \
-from Django Rest Framework code."""
+
+description = "Automated generation of real Swagger/OpenAPI 2.0 schemas from Django Rest Framework code."
+
 keywords = [
   "codegen",
   "django",
@@ -58,6 +61,7 @@ keywords = [
   "swagger",
   "swagger-codegen",
 ]
+
 license = "BSD-3-Clause"
 license-files = [ "LICENSE.rst" ]
 readme =  "README.rst"
@@ -104,5 +108,3 @@ lint.mccabe.max-complexity = 13
 lint.per-file-ignores."src/drf_yasg/inspectors/field.py" = [ "E721" ]
 lint.per-file-ignores."src/drf_yasg/openapi.py" = [ "E721" ]
 lint.per-file-ignores."testproj/testproj/settings/*" = [ "F405" ]
-
-[tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
+requires = [ "setuptools >= 77.0.3", "setuptools-scm ~= 7.0" ]
 build-backend = "setuptools.build_meta"
-
-requires = [ "setuptools>=68", "setuptools-scm>=3.0.3", "wheel" ]
 
 [tool.ruff]
 exclude = [ "**/migrations/*" ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,0 @@
-djangorestframework>=3.10.3
-django>=2.2.16
-pyyaml>=5.1
-inflection>=0.3.1
-packaging>=21.0
-pytz>=2021.1
-uritemplate>=3.0.0

--- a/requirements/publish.txt
+++ b/requirements/publish.txt
@@ -1,3 +1,2 @@
-setuptools-scm==7.0.5
+build
 twine>=5.0.0
-wheel>=0.37.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,11 +1,10 @@
 # requirements for running the tests via pytest
-pytest>=4.0
-pytest-pythonpath>=0.7.1
-pytest-cov>=2.6.0
-pytest-xdist>=1.25.0
-pytest-django>=3.4.4
-datadiff==2.0.0
-psycopg2-binary==2.9.5
+datadiff>=2
 django-fake-model==0.1.4
+psycopg2-binary>=2.9.5
+pytest-cov>=4
+pytest-django>=4
+pytest-xdist>=3
+pytest>=7
 
 -r testproj.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -1,2 +1,2 @@
 # requirements for building and running tox
-tox>=3.3.0,<4
+tox~=4.0

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -1,2 +1,0 @@
-# requirements for the validation feature
-swagger-spec-validator>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ python_requires = ">=" + python_versions[0]
 python_classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ] + ["Programming Language :: Python :: {}".format(v) for v in python_versions]
 django_classifiers = [
     "Framework :: Django",

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import print_function
-
-import io
 import os
 import sys
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 
 def read_req(req_file):
@@ -18,72 +14,17 @@ def read_req(req_file):
         ]
 
 
-with io.open("README.rst", encoding="utf-8") as readme:
-    description = readme.read()
-
 requirements = read_req("base.txt")
 requirements_validation = read_req("validation.txt")
 
 
-def find_versions_from_readme(prefix):
-    for line in description.splitlines():
-        line = line.strip()
-        if line.startswith(prefix):
-            versions = [v.strip() for v in line[len(prefix) :].split(",")]
-            if versions:
-                return versions
-
-    raise RuntimeError("failed to find supported versions list for '{}'".format(prefix))
-
-
-python_versions = find_versions_from_readme("- **Python**: ")
-django_versions = find_versions_from_readme("- **Django**: ")
-
-python_requires = ">=" + python_versions[0]
-
-python_classifiers = [
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3 :: Only",
-] + ["Programming Language :: Python :: {}".format(v) for v in python_versions]
-django_classifiers = [
-    "Framework :: Django",
-] + ["Framework :: Django :: {}".format(v) for v in django_versions]
-
-
 def drf_yasg_setup(**kwargs):
     setup(
-        name="drf-yasg",
-        packages=find_packages("src"),
-        package_dir={"": "src"},
-        include_package_data=True,
         install_requires=requirements,
         extras_require={
             "validation": requirements_validation,
             "coreapi": ["coreapi>=2.3.3", "coreschema>=0.0.4"],
         },
-        license="BSD License",
-        description="Automated generation of real Swagger/OpenAPI 2.0 schemas from "
-        "Django Rest Framework code.",
-        long_description=description,
-        long_description_content_type="text/x-rst",
-        url="https://github.com/axnsan12/drf-yasg",
-        author="Cristi V.",
-        author_email="cristi@cvjd.me",
-        keywords="drf django django-rest-framework schema swagger openapi codegen "
-        "swagger-codegen documentation drf-yasg django-rest-swagger drf-openapi",
-        python_requires=python_requires,
-        classifiers=[
-            "Intended Audience :: Developers",
-            "License :: OSI Approved :: BSD License",
-            "Development Status :: 5 - Production/Stable",
-            "Operating System :: OS Independent",
-            "Environment :: Web Environment",
-            "Topic :: Documentation",
-            "Topic :: Software Development :: Code Generators",
-        ]
-        + python_classifiers
-        + django_classifiers,
         **kwargs,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,15 @@
 #!/usr/bin/env python
-import os
-import sys
-
 from setuptools import setup
-
-
-def read_req(req_file):
-    with open(os.path.join("requirements", req_file)) as req:
-        return [
-            line.strip()
-            for line in req.readlines()
-            if line.strip() and not line.strip().startswith("#")
-        ]
-
-
-requirements = read_req("base.txt")
-requirements_validation = read_req("validation.txt")
-
-
-def drf_yasg_setup(**kwargs):
-    setup(
-        install_requires=requirements,
-        extras_require={
-            "validation": requirements_validation,
-            "coreapi": ["coreapi>=2.3.3", "coreschema>=0.0.4"],
-        },
-        **kwargs,
-    )
-
 
 try:
     # noinspection PyUnresolvedReferences
     import setuptools_scm  # noqa: F401
 
-    drf_yasg_setup(use_scm_version=True)
+    setup(use_scm_version=True)
 except (ImportError, LookupError) as e:
+    import os
+    import sys
+
     if os.getenv("CI", "false") == "true":
         # don't silently fail on CI - we don't want to accidentally push a dummy version
         # to PyPI
@@ -49,7 +24,7 @@ except (ImportError, LookupError) as e:
         timestamp_str = hex(timestamp_ms)[2:].zfill(16)
         dummy_version = "1!0.0.0.dev0+noscm." + timestamp_str
 
-        drf_yasg_setup(version=dummy_version)
+        setup(version=dummy_version)
 
         traceback.print_exc(file=sys.stderr)
         print(

--- a/tox.ini
+++ b/tox.ini
@@ -1,41 +1,30 @@
 [tox]
-minversion = 3.3.0
-isolated_build = true
-isolated_build_env = .package
+minversion = 4.0.0
 
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py{37,38,39}-django{22,30}-drf{310,311,312},
-    py{37,38,39}-django{31,32}-drf{311,312},
-    py{39,310}-django{40,41}-drf{313,314},
-    py311-django{40,41,42,50,51}-drf315,
-    py312-django{42,50,51}-drf315,
-    py313-django{51}-drf315,
-    py38-{lint, docs},
-    # py313-djmaster  # ModuleNotFoundError: No module named 'psycopg'
+    py3{9,10,11,12   }-django40-drf{313,314,315},
+    py3{9,10,11,12,13}-django41-drf{313,314,315},
+    py3{9,10,11,12,13}-django42-drf{314,315},
+    py3{  10,11,12,13}-django50-drf{314,315},
+    py3{  10,11,12,13}-django5{1,2}-drf{315},
+    py3{        12,13}-prerelease,
+    py39-{lint,docs}
 
 skip_missing_interpreters = true
 
-[testenv:.package]
-# no additional dependencies besides PEP 517
-deps =
-
-[testenv:py310-djmaster]
+[testenv:py31{2,3}-prerelease]
 ignore_outcome = true
 
 [testenv]
 deps =
-    django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
-    django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5
+    django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<6
 
-    drf310: djangorestframework>=3.10,<3.11
-    drf311: djangorestframework>=3.11,<3.12
-    drf312: djangorestframework>=3.12,<3.13
     drf313: djangorestframework>=3.13,<3.14
     drf314: djangorestframework>=3.14,<3.15
     drf315: djangorestframework>=3.15,<3.16
@@ -44,20 +33,16 @@ deps =
 
     # test with the latest builds of Django and django-rest-framework
     # to get early warning of compatibility issues
-    djmaster: https://github.com/django/django/archive/main.tar.gz
-    djmaster: https://github.com/encode/django-rest-framework/archive/master.tar.gz
+    prerelease: https://github.com/django/django/archive/main.tar.gz
+    prerelease: https://github.com/encode/django-rest-framework/archive/master.tar.gz
 
     # other dependencies
-    -r requirements/validation.txt
     -r requirements/test.txt
-    drf310: coreapi>=2.3.3
-    drf310: coreschema>=0.0.4
-    drf310: flex~=6.14.1
-
+extras = validation
 commands =
-    pytest -n 2 --cov --cov-config .coveragerc --cov-append --cov-report="" {posargs}
+    pytest -n auto --cov --cov-config .coveragerc --cov-append --cov-report="" {posargs}
 
-[testenv:py38-lint]
+[testenv:py39-lint]
 skip_install = true
 deps =
     -r requirements/lint.txt
@@ -65,26 +50,14 @@ commands =
     ruff check
     ruff format --check
 
-[testenv:py38-docs]
+[testenv:py39-docs]
 deps =
     -r requirements/docs.txt
+extras = validation
 commands =
     sphinx-build -WnEa -b html docs docs/_build/html
 
 [pytest]
 DJANGO_SETTINGS_MODULE = testproj.settings.local
-python_paths = testproj
+pythonpath = testproj
 addopts = --ignore=node_modules
-
-[flake8]
-max-line-length = 120
-exclude = **/migrations/*
-ignore = E721,F405,I001,I005,W504
-
-[isort]
-skip = .eggs,.tox,docs,env,venv,node_modules,.git
-skip_glob = **/migrations/*
-atomic = true
-multi_line_output = 5
-line_length = 120
-known_first_party = drf_yasg,testproj,articles,people,snippets,todo,users,urlconfs


### PR DESCRIPTION
This change is a proposal, it drops the EoL Python versions, and limits the Django support to the last two major versions (~4 years since release) and the DRF versions that support those versions.