### PR TITLE
Fixes issue with filter parameters not appearing in Swagger after upgrading to django-filter>=25

### DIFF
--- a/src/drf_yasg/inspectors/query.py
+++ b/src/drf_yasg/inspectors/query.py
@@ -57,7 +57,6 @@ class DrfAPICompatInspector(PaginatorInspector, FilterInspector):
         return NotHandled
 
     def get_filter_backend_params(self, filter_backend):
-
         filterset_class = filter_backend.get_filterset_class(
             self.view,
             self.view.queryset,


### PR DESCRIPTION
This pull request addresses an incompatibility between `django-filter version >=25` and `drf-yasg`. In recent versions, `django-filter` has removed the get_schema_operation_parameters method, which previously allowed `drf-yasg` to display filter parameters in the Swagger UI.

To resolve this, I’ve introduced a new function` get_filter_backend_params` that extracts the `filterset class` from the `filterset backend` and dynamically populates the relevant filter fields for schema generation. This ensures that filter parameters are correctly displayed in the Swagger documentation when using `django-filter >=25.`

**Changes**
- Added `get_filter_backend_params` utility function.
- Modified schema generation logic to use this function as a fallback when `get_schema_operation_parameters` is not available.


![image](https://github.com/user-attachments/assets/cba9d9da-6a36-461f-8a45-7fd3a2162ade)

