### PR TITLE
Remove usage of pkg_resources

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ from docutils.parsers.rst.roles import set_classes
 try:
     from importlib import metadata
 except ImportError:  # Python < 3.8
-    from pkg_resources import get_distribution
+    import importlib_metadata as metadata
 
 # -- General configuration ------------------------------------------------
 
@@ -51,10 +51,7 @@ author = "Cristi V."
 # built documents.
 
 # The full version, including alpha/beta/rc tags.
-try:
-    release = metadata.version("drf_yasg")
-except NameError:  # Python < 3.8
-    release = get_distribution("drf_yasg").version
+release = metadata.version("drf_yasg")
 if "noscm" in release:
     raise AssertionError(
         "Invalid package version string: %s. \n"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,3 +5,4 @@ inflection>=0.3.1
 packaging>=21.0
 pytz>=2021.1
 uritemplate>=3.0.0
+importlib_metadata; python_version < '3.8'

--- a/src/drf_yasg/__init__.py
+++ b/src/drf_yasg/__init__.py
@@ -5,13 +5,7 @@ __email__ = "cristi@cvjd.me"
 
 try:
     from importlib.metadata import version
-
-    __version__ = version(__name__)
 except ImportError:  # Python < 3.8
-    try:
-        from pkg_resources import DistributionNotFound, get_distribution
+    from importlib_metadata import version
 
-        __version__ = get_distribution(__name__).version
-    except DistributionNotFound:  # pragma: no cover
-        # package is not installed
-        pass
+__version__ = version(__name__)

--- a/src/drf_yasg/inspectors/field.py
+++ b/src/drf_yasg/inspectors/field.py
@@ -27,12 +27,10 @@ from .base import FieldInspector, NotHandled, SerializerInspector, call_view_met
 
 try:
     from importlib import metadata
-
-    drf_version = metadata.version("djangorestframework")
 except ImportError:  # Python < 3.8
-    import pkg_resources
+    import importlib_metadata as metadata
 
-    drf_version = pkg_resources.get_distribution("djangorestframework").version
+drf_version = metadata.version("djangorestframework")
 
 try:
     from types import NoneType, UnionType


### PR DESCRIPTION
This PR fixes the implicit dependence of drf-yasg on setuptools.

## Premise

[Earlier changes](https://github.com/axnsan12/drf-yasg/pull/891) have already addressed the undefined _build_ dependency on setuptools. However, this did not fix the problem of the implicit, undefined _runtime_ dependency on setuptools.

In this case, it's not about setuptools _per sé_, but about `pkg_resources`. The latter is a Python module that was removed in version 3.12, but was kept in setuptools. drf-yasg uses `pkg_resources` only to infer its own version; This can already be done with `importlib.metadata`, but that module was first introduced with Python 3.8. As such, we can't use it on older version.

On older Pythons, `pkg_resources` is used instead. It, however, is _not_ a part of Python's standard library, but of setuptools. In the olden days, it was a safe bet that setuptools is included with your Python installation/virtual environment. But nowadays, some venv creators (especially poetry and uv) no longer include setuptools when seeding virtual environments, causing drf-yasg to break on older Python versions using these venv managers.

This is related to #874, #875

### Reproducible "bug"

Using uv:

```bash
uv init --app -p3.7
uv add 'django==3.2.*' drf-yasg
uv run python -c 'import drf_yasg'
```

```
Traceback (most recent call last):
  File "/private/var/folders/ls/852qp1t519l3df8b7fdphh500000gn/T/tempdir-PqLOBF/.venv/lib/python3.7/site-packages/drf_yasg/__init__.py", line 7, in <module>
    from importlib.metadata import version
ModuleNotFoundError: No module named 'importlib.metadata'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/var/folders/ls/852qp1t519l3df8b7fdphh500000gn/T/tempdir-PqLOBF/.venv/lib/python3.7/site-packages/drf_yasg/__init__.py", line 11, in <module>
    from pkg_resources import DistributionNotFound, get_distribution
ModuleNotFoundError: No module named 'pkg_resources'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/private/var/folders/ls/852qp1t519l3df8b7fdphh500000gn/T/tempdir-PqLOBF/.venv/lib/python3.7/site-packages/drf_yasg/__init__.py", line 13, in <module>
    except DistributionNotFound:  # pragma: no cover
NameError: name 'DistributionNotFound' is not defined
```

## Solution

This PR includes the `importlib_metadata` backport as a dependency and replaces `pkg_resources.get_distribution(...).version` with `importlib_metadata.version`. I have defined the dependency in such a way that it is only included on Python versions below 3.8. **It is important to note** that this breaks the `requirements.txt` "format" of base.txt file by adding extra stuff to the dependency line. As long as base.txt is not being used directly in a `pip install` command, it's fine; otherwise, the said `pip` command might fail. Since base.txt is only used to infer `install_requires`, it should be fine.

Closes #851

### Alternative solutions and ideas

#### No `python_version < '3.8'`

I have considered defining the dependency on `importlib_metadata` non-dynamically, i.e. not dependent on the target Python version. This has a disadvantage of the dependency being installed as a dead weight on more than 95% of installs.

<details>
<summary>Download statistics of drf-yasg, grouped by Python minor version</summary>

| category | percent | downloads |
| :--------|-------: |---------: |
| 3.11     |  30.28% |   713,260 |
| 3.12     |  18.84% |   443,693 |
| 3.10     |  18.28% |   430,699 |
| 3.9      |  10.39% |   244,644 |
| null     |   8.48% |   199,677 |
| 3.8      |   6.53% |   153,866 |
| 3.13     |   3.22% |    75,930 |
| 3.7      |   3.16% |    74,499 |
| 3.6      |   0.64% |    15,138 |
| 2.7      |   0.16% |     3,815 |
| 3.14     |   0.01% |       189 |
| 3.5      |   0.01% |       167 |
| Total    |         | 2,355,577 |

Date range: 2025-03-01 - 2025-03-31

</details>

#### Include `setuptools` as dependency

setuptools is a huge project, and including it as a dependency is counter-intuitive and potentially dangerous. Also, continuing to use `pkg_resources` (an obsolete API) is never a good idea.

#### Throw away base.txt

This is something I am the biggest fan of. Since we only use base.txt to infer the value for `python_requires` in setup.py, why not just get rid of the file and declare the dependencies directly in the `setup()` call?

#### Remove support on Python 3.6 and 3.7

Both Python 3.6 and 3.7, as well as Django 3.2 (the last version to support these Python versions) are EOL, meaning we could just remove support for it and remove the need for `importlib_metadata` completely. This would require a major version bump, though, so I have mixed feelings about this.

---

Please let me know if the solution is acceptable for you; I am open for any suggestions :)