### PR TITLE
Update logout button to use POST request.

### DIFF
--- a/src/drf_yasg/static/drf-yasg/style.css
+++ b/src/drf_yasg/static/drf-yasg/style.css
@@ -71,3 +71,12 @@ svg.swagger-defs {
     width: 0;
     height: 0;
 }
+
+button.header__btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+}

--- a/src/drf_yasg/templates/drf-yasg/swagger-ui.html
+++ b/src/drf_yasg/templates/drf-yasg/swagger-ui.html
@@ -59,26 +59,25 @@
             {% block user_context_message %}
                 {% if request.user.is_authenticated %}
                     <div class="hello">
-                        <span class="django-session">Django</span> <span
-                            class="label label-primary">{{ request.user }}</span>
+                        <span class="django-session">Django</span>
+                        <span class="label label-primary">{{ request.user }}</span>
                     </div>
                 {% endif %}
             {% endblock %}
 
             {% if request.user.is_authenticated %}
                 <div class='btn authorize'>
-                    <a id="auth" class="header__btn" href="{{ LOGOUT_URL }}?next={{ request.path }}" data-sw-translate>
-                        {% block django_logout_message %}
-                            Django Logout
-                        {% endblock %}
-                    </a>
+                    <form method="post" action="{{ LOGOUT_URL }}?next={{ request.path }}">
+                        {% csrf_token %}
+                        <button type="submit" id="auth" class="header__btn" data-sw-translate>
+                        {% block django_logout_message %}Django Logout{% endblock %}
+                        </button>
+                    </form>
                 </div>
             {% else %}
                 <div class='btn authorize'>
                     <a id="auth" class="header__btn" href="{{ LOGIN_URL }}?next={{ request.path }}" data-sw-translate>
-                        {% block django_login_message %}
-                            Django Login
-                        {% endblock %}
+                        {% block django_login_message %}Django Login{% endblock %}
                     </a>
                 </div>
             {% endif %}


### PR DESCRIPTION
Presumably, most users use a LOGOUT_URL that maps to Django's LogoutView. However, using GET with LogoutView has been deprecated since Django 4.1. We update the logout button to use POST instead.

This may be a breaking change for any users that have implemented a custom GET-based logout page. These users can either switch to LogoutView which now works again out of the box. Or, adapt their view to also accept POST requests. Or, override `swagger-ui.html` template to use a simple `<a>` link.

Fixes #733.

See: https://docs.djangoproject.com/en/dev/releases/4.1/#log-out-via-get