### PR TITLE
Simplify zoneinfo import

### DIFF
--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 import textwrap
+import zoneinfo
 from decimal import Decimal
 
 import pytz
@@ -20,15 +21,6 @@ from rest_framework.utils import encoders, json
 from rest_framework.views import APIView
 
 from .app_settings import swagger_settings
-
-try:
-    import zoneinfo
-except ImportError:
-    try:
-        from backports import zoneinfo
-    except ImportError:
-        zoneinfo = None
-
 
 logger = logging.getLogger(__name__)
 
@@ -605,7 +597,7 @@ def field_value_to_representation(field, value):
     elif isinstance(value, pytz.BaseTzInfo):
         value = str(value)
 
-    elif zoneinfo is not None and isinstance(value, zoneinfo.ZoneInfo):
+    elif isinstance(value, zoneinfo.ZoneInfo):
         value = str(value)
 
     # JSON roundtrip ensures that the value is valid JSON;


### PR DESCRIPTION
Since [zoneinfo](https://docs.python.org/3/library/zoneinfo.html) is added to standard lib in 3.9 and 3.10+ is required here, it's no longer necessary to try importing it.