### PR TITLE
Remove pytz dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "djangorestframework >= 3.13",
     "inflection >= 0.3.1",
     "packaging >= 21.0",
-    "pytz >= 2021.1",
     "pyyaml >= 5.1",
     "swagger-spec-validator >= 2.1.0",
     "uritemplate >= 3.0.0",

--- a/src/drf_yasg/utils.py
+++ b/src/drf_yasg/utils.py
@@ -4,7 +4,6 @@ import textwrap
 import zoneinfo
 from decimal import Decimal
 
-import pytz
 from django.db import models
 from django.utils.encoding import force_str
 from rest_framework import serializers, status
@@ -21,6 +20,11 @@ from rest_framework.utils import encoders, json
 from rest_framework.views import APIView
 
 from .app_settings import swagger_settings
+
+try:
+    import pytz
+except ImportError:
+    pytz = None
 
 logger = logging.getLogger(__name__)
 
@@ -594,7 +598,7 @@ def field_value_to_representation(field, value):
         else:
             value = str(value)
 
-    elif isinstance(value, pytz.BaseTzInfo):
+    elif pytz is not None and isinstance(value, pytz.BaseTzInfo):
         value = str(value)
 
     elif isinstance(value, zoneinfo.ZoneInfo):

--- a/uv.lock
+++ b/uv.lock
@@ -650,7 +650,6 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "inflection" },
     { name = "packaging" },
-    { name = "pytz" },
     { name = "pyyaml" },
     { name = "swagger-spec-validator" },
     { name = "uritemplate" },
@@ -695,7 +694,6 @@ requires-dist = [
     { name = "djangorestframework", specifier = ">=3.13" },
     { name = "inflection", specifier = ">=0.3.1" },
     { name = "packaging", specifier = ">=21.0" },
-    { name = "pytz", specifier = ">=2021.1" },
     { name = "pyyaml", specifier = ">=5.1" },
     { name = "swagger-spec-validator", specifier = ">=2.1.0" },
     { name = "uritemplate", specifier = ">=3.0.0" },
@@ -1390,15 +1388,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/bb/93a3e83bdf9322c7e21cafd092e56a4a17c4d8ef4277b6eb01af1a540a6f/python_discovery-1.1.0.tar.gz", hash = "sha256:447941ba1aed8cc2ab7ee3cb91be5fc137c5bdbb05b7e6ea62fbdcb66e50b268", size = 55674, upload-time = "2026-02-26T09:42:49.668Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/54/82a6e2ef37f0f23dccac604b9585bdcbd0698604feb64807dcb72853693e/python_discovery-1.1.0-py3-none-any.whl", hash = "sha256:a162893b8809727f54594a99ad2179d2ede4bf953e12d4c7abc3cc9cdbd1437b", size = 30687, upload-time = "2026-02-26T09:42:48.548Z" },
-]
-
-[[package]]
-name = "pytz"
-version = "2026.1.post1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
A project I'm working on moved from pytz to zoneinfo, but can't drop the pytz dependency because drf-yasg depends on it. Turns out that drf-yasg doesn't rely on functionalities that pytz provides, but only checks if a parameter is of specific type. So this PR drops pytz as a dependency, and uses the same try import method that zoneinfo had (prior to #964), to preserve the behavior.